### PR TITLE
Remove SECI 1 on install.

### DIFF
--- a/installation_and_upgrade/ibex_install_utils/file_utils.py
+++ b/installation_and_upgrade/ibex_install_utils/file_utils.py
@@ -12,16 +12,19 @@ class FileUtils(object):
     """
 
     @staticmethod
-    def remove_tree(path):
+    def remove_tree(path, use_robocopy=True):
         """
         Delete a file path if it exists
         Args:
             path: path to delete
         """
-        empty_dir = r"\\isis\inst$\Kits$\CompGroup\ICP\empty_dir_for_robocopy"
-        if os.path.isdir(path):
-            os.system("robocopy \"{}\" \"{}\" /PURGE /NJH /NJS /NP /NFL /NDL /NS /NC /R:1 /LOG:NUL".
-                      format(empty_dir, path))
+        if use_robocopy:
+            empty_dir = r"\\isis\inst$\Kits$\CompGroup\ICP\empty_dir_for_robocopy"
+            if os.path.isdir(path):
+                os.system("robocopy \"{}\" \"{}\" /PURGE /NJH /NJS /NP /NFL /NDL /NS /NC /R:1 /LOG:NUL".
+                          format(empty_dir, path))
+        else:
+            shutil.rmtree(path)
 
     def mkdir_recursive(self, path):
         """

--- a/installation_and_upgrade/ibex_install_utils/install_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/install_tasks.py
@@ -40,6 +40,7 @@ LABVIEW_DAE_DIR = os.path.join("C:\\", "LabVIEW modules", "DAE")
 USER_START_MENU = os.path.join("C:\\", "users", "spudulike", "AppData", "Roaming", "Microsoft", "Windows", "Start Menu")
 PC_START_MENU = os.path.join("C:\\", "ProgramData", "Microsoft", "Windows", "Start Menu")
 SECI = "SECI User interface.lnk"
+SECI_ONE_PATH = os.path.join("C:\\", "Program Files (x86)", "CCLRC ISIS Facility")
 AUTOSTART_LOCATIONS = [os.path.join(USER_START_MENU, "Programs", "Startup", SECI),
                        os.path.join(PC_START_MENU, "Programs", "Startup", SECI)]
 
@@ -349,6 +350,16 @@ class UpgradeTasks(object):
                 self._prompt.prompt_and_raise_if_not_yes("Remove task bar shortcut to SECI")
                 self._prompt.prompt_and_raise_if_not_yes("Remove desktop shortcut to SECI")
                 self._prompt.prompt_and_raise_if_not_yes("Remove start menu shortcut to SECI")
+
+    def remove_seci_one(self):
+        """
+        Removes SECI 1
+        Returns:
+
+        """
+        with Task("Remove SECI 1 Path: {}".format(SECI_ONE_PATH), self._prompt) as task:
+            if task.do_step:
+                self._file_utils.remove_tree(SECI_ONE_PATH, use_robocopy=False)
 
     def setup_calibrations_repository(self):
         """
@@ -824,6 +835,7 @@ class UpgradeInstrument(object):
         self._upgrade_tasks.check_java_installation()
         self._upgrade_tasks.install_mysql()
         self._upgrade_tasks.remove_seci_shortcuts()
+        self._upgrade_tasks.remove_seci_one()
 
         self._upgrade_tasks.install_ibex_server(self._should_install_utils())
         self._upgrade_tasks.install_ibex_client()

--- a/installation_and_upgrade/ibex_install_utils/install_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/install_tasks.py
@@ -354,12 +354,16 @@ class UpgradeTasks(object):
     def remove_seci_one(self):
         """
         Removes SECI 1
-        Returns:
-
         """
-        with Task("Remove SECI 1 Path: {}".format(SECI_ONE_PATH), self._prompt) as task:
+        with Task("Remove SECI 1 Path", self._prompt) as task:
             if task.do_step:
-                self._file_utils.remove_tree(SECI_ONE_PATH, use_robocopy=False)
+                if os.path.exists(SECI_ONE_PATH):
+                    try:
+                        self._file_utils.remove_tree(SECI_ONE_PATH, use_robocopy=False)
+                    except (IOError, WindowsError) as e:
+                        self._prompt.prompt_and_raise_if_not_yes("Failed to remove SECI 1 (located in '{}') because "
+                                                                 "'{}'. Please remove it manually and type 'Y' to "
+                                                                 "confirm".format(SECI_ONE_PATH, e.message))
 
     def setup_calibrations_repository(self):
         """


### PR DESCRIPTION
A fresh install of IBEX will now delete SECI 1 directory "c\Program Files (x86)\CCLRC ISIS Facility".

To test, create that directory, fill with files/directories and run "C:\Instrument\Dev\ibex_utils\installation_and_upgrade\instrument_install.bat".
You will need to have both admin rights to your machine and access rights to "\\isis\inst$\Kits$\C
KeyboardInterrupty_dir_for_robocopy".
Select Y when asked if you want to remove SECI 1, then make sure it has been deleted.