### PR TITLE
Create dir and clone in one step, raise error in case of failure

### DIFF
--- a/installation_and_upgrade/ibex_install_utils/install_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/install_tasks.py
@@ -556,7 +556,7 @@ class UpgradeTasks(object):
         Set up the calibration repository
         """
         if os.path.isdir(CALIBRATION_PATH):
-            if self.prompt("Calibrations directory already exists. Update calibrations repository?",
+            if self.prompt.prompt("Calibrations directory already exists. Update calibrations repository?",
                            ["Y", "N"], "N") == "Y":
                 self.update_calibrations_repository()
         else:

--- a/installation_and_upgrade/ibex_install_utils/install_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/install_tasks.py
@@ -560,9 +560,10 @@ class UpgradeTasks(object):
                            ["Y", "N"], "N") == "Y":
                 self.update_calibrations_repository()
         else:
-            os.makedirs(CALIBRATION_PATH)
-            subprocess.call("git clone http://control-svcs.isis.cclrc.ac.uk/gitroot/instconfigs/common.git "
-                            "C:\Instrument\Settings\config\common", cwd=CALIBRATION_PATH)
+            exit_code = subprocess.call("git clone http://control-svcs.isis.cclrc.ac.uk/gitroot/instconfigs/common.git "
+                            "C:\Instrument\Settings\config\common")
+            if exit_code is not 0:
+                raise ErrorInRun("Failed to set up common calibration directory.")
 
     @task("Updating calibrations repository")
     def update_calibrations_repository(self):


### PR DESCRIPTION
Changed the `setup_calibrations_repository` upgrade step, such that
1. It raises an error in case of the `git clone` failing. This raises the visibility of the failure as it prompts a user response to retry, skip or abort.
1. It creates the `common` folder as part of the git instruction. When the `git clone` failed previously, the directory would still be created. This would then lead to the install script skipping to trying (and failing) to update the directory in any subsequent run.
1. Fixed syntax in a call to `prompt`.


Issue: https://github.com/ISISComputingGroup/IBEX/issues/3722