### PR TITLE
Ticket 4347: Added installation step to update kafka topics

### DIFF
--- a/installation_and_upgrade/ibex_install_utils/install_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/install_tasks.py
@@ -24,6 +24,7 @@ from ibex_install_utils.run_process import RunProcess
 from ibex_install_utils.task import task
 from ibex_install_utils.user_prompt import UserPrompt
 from ibex_install_utils.motor_params import get_params_and_save_to_file
+from ibex_install_utils.kafka_utils import add_required_topics
 
 BACKUP_DATA_DIR = os.path.join("C:\\", "data")
 BACKUP_DIR = os.path.join(BACKUP_DATA_DIR, "old")
@@ -178,6 +179,7 @@ class UpgradeInstrument(object):
         self._upgrade_tasks.add_nagios_checks()
         self._upgrade_tasks.update_instlist()
         self._upgrade_tasks.update_web_dashboard()
+        self._upgrade_tasks.update_kafka_topics()
         self._upgrade_tasks.put_autostart_script_in_startup_area()
 
     def run_instrument_deploy(self):
@@ -1017,6 +1019,13 @@ class UpgradeTasks(object):
         self.prompt.prompt_and_raise_if_not_yes(
             "Restart JSON_bourne on NDAEXTWEB1 when appropriate. "
             "(WARNING: This will kill all existing sessions!)")
+
+    @task("Update kafka topics")
+    def update_kafka_topics(self):
+        """
+        Adds the required kafka topics to the cluster.
+        """
+        add_required_topics("livedata.isis.cclrc.ac.uk:9092", self._get_instrument_name())
 
     @task("Install wiring tables")
     def install_wiring_tables(self):

--- a/installation_and_upgrade/ibex_install_utils/kafka_utils.py
+++ b/installation_and_upgrade/ibex_install_utils/kafka_utils.py
@@ -4,6 +4,10 @@ from kafka.admin import KafkaAdminClient, NewTopic
 REQUIRED_SUFFIXES = ["_events", "_sampleEnv", "_runInfo", "_epicsForwarderConfig", "_detSpecMap"]
 
 
+def get_existing_topics(kafka_broker):
+    return KafkaConsumer(bootstrap_servers=[kafka_broker]).topics()
+
+
 def add_required_topics(kafka_broker, instrument):
     """
     Adds required Kafka topics for the instrument
@@ -13,9 +17,7 @@ def add_required_topics(kafka_broker, instrument):
         instrument: the name of the instrument for which to add the topics
     """
     required_topics = set(instrument + suffix for suffix in REQUIRED_SUFFIXES)
-
-    consumer = KafkaConsumer(bootstrap_servers=[kafka_broker])
-    existing_topics = set(filter(lambda topic: topic.startswith(instrument), consumer.topics()))
+    existing_topics = set(filter(lambda topic: topic.startswith(instrument), get_existing_topics()))
 
     if required_topics != existing_topics:
         topic_names_to_add = required_topics - existing_topics

--- a/installation_and_upgrade/ibex_install_utils/kafka_utils.py
+++ b/installation_and_upgrade/ibex_install_utils/kafka_utils.py
@@ -17,7 +17,7 @@ def add_required_topics(kafka_broker, instrument):
         instrument: the name of the instrument for which to add the topics
     """
     required_topics = set(instrument + suffix for suffix in REQUIRED_SUFFIXES)
-    existing_topics = set(filter(lambda topic: topic.startswith(instrument), get_existing_topics()))
+    existing_topics = set(filter(lambda topic: topic.startswith(instrument), get_existing_topics(kafka_broker)))
 
     if required_topics != existing_topics:
         topic_names_to_add = required_topics - existing_topics

--- a/installation_and_upgrade/ibex_install_utils/kafka_utils.py
+++ b/installation_and_upgrade/ibex_install_utils/kafka_utils.py
@@ -1,0 +1,26 @@
+from kafka import KafkaConsumer
+from kafka.admin import KafkaAdminClient, NewTopic
+
+REQUIRED_SUFFIXES = ["_events", "_sampleEnv", "_runInfo", "_epicsForwarderConfig", "_detSpecMap"]
+
+
+def add_required_topics(kafka_broker, instrument):
+    """
+    Adds required Kafka topics for the instrument
+
+    Args:
+        kafka_broker: the broker to add the topics to
+        instrument: the name of the instrument for which to add the topics
+    """
+    required_topics = set(instrument + suffix for suffix in REQUIRED_SUFFIXES)
+
+    consumer = KafkaConsumer(bootstrap_servers=[kafka_broker])
+    existing_topics = set(filter(lambda topic: topic.startswith(instrument), consumer.topics()))
+
+    if required_topics != existing_topics:
+        topic_names_to_add = required_topics - existing_topics
+
+        topic_list = [NewTopic(name=name, num_partitions=1, replication_factor=3) for name in topic_names_to_add]
+
+        admin_client = KafkaAdminClient(bootstrap_servers=kafka_broker, client_id='install_script')
+        admin_client.create_topics(new_topics=topic_list, validate_only=False)


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/4347

Requires https://github.com/ISISComputingGroup/genie_python/pull/164

To test:
```
from ibex_install_utils.kafka_utils import get_existing_topics, add_required_topics
get_existing_topics("tenten.isis.cclrc.ac.uk:9092")
```

Confirm that your instrument isn't in there.

Run `add_required_topics("tenten.isis.cclrc.ac.uk:9092", "YOUR_INST")` and the above again to confirm your instrument is now in the list.

