### PR TITLE
Allow alternative install source prefix

### DIFF
--- a/installation_and_upgrade/IBEX_upgrade.py
+++ b/installation_and_upgrade/IBEX_upgrade.py
@@ -46,6 +46,7 @@ if __name__ == "__main__":
     parser.add_argument("--release_suffix", dest="release_suffix", default="",
                         help="Suffix for specifying non-standard releases "
                              "(such as those including hot fixes)")
+    parser.add_argument("--server_build_prefix", default="EPICS", help="Prefix for build directory name")
     parser.add_argument("--server_dir", default=None, help="Directory from which IBEX server should be installed")
     parser.add_argument("--client_dir", default=None, help="Directory from which IBEX client should be installed")
     parser.add_argument("--client_e4_dir", default=None, help="Directory from which IBEX E4 client should be installed")
@@ -90,9 +91,9 @@ if __name__ == "__main__":
             print("When specifying kits_icp_dir you choose the install latest deployment type.")
             sys.exit(2)
         if args.deployment_type == 'install_latest_incr':
-            epics_build_dir = os.path.join(args.kits_icp_dir, "EPICS", "EPICS_win7_x64")
+            epics_build_dir = os.path.join(args.kits_icp_dir, "EPICS", args.server_build_prefix+"_win7_x64")
         else:
-            epics_build_dir = os.path.join(args.kits_icp_dir, "EPICS", "EPICS_CLEAN_win7_x64")
+            epics_build_dir = os.path.join(args.kits_icp_dir, "EPICS", args.server_build_prefix+"_CLEAN_win7_x64")
         server_dir = _get_latest_directory_path(epics_build_dir, "BUILD-", "EPICS")
 
         client_build_dir = os.path.join(args.kits_icp_dir, "Client")

--- a/installation_and_upgrade/instrument_install_latest_build_only.bat
+++ b/installation_and_upgrade/instrument_install_latest_build_only.bat
@@ -1,12 +1,27 @@
 REM Install latest version of IBEX
 
+REM argument 1 is CLEAN or INCR for type of build touse (default: CLEAN)
+
+REM argument 2 is a server build prefix
+REM normally will use EPICS_win7_x64 or EPICS_CLEAN_win7_x64 depending on incremental/clean
+REM with prefix specified will use {prefix}_win7_x64 and {prefix}_CLEAN_win7_x64 for server install source directory
+ 
 call "%~dp0\define_latest_genie_python.bat"
 
 set "STOP_IBEX=C:\Instrument\Apps\EPICS\stop_ibex_server.bat"
 set "START_IBEX=C:\Instrument\Apps\EPICS\start_ibex_server.bat"
 IF EXIST "C:\Instrument\Apps\EPICS" (call "%STOP_IBEX%")
 
-call "%LATEST_PYTHON%" "%~dp0IBEX_upgrade.py" --kits_icp_dir "%KITS_ICP_PATH%"  --quiet install_latest
+if not "%2" == "" (
+    @echo Using server build prefix %2
+    set SERVER_BUILD_PREFIX=--server_build_prefix "%2"
+)
+set INSTALL_TYPE=install_latest
+if "%1" == "INCR" (
+    set INSTALL_TYPE=install_latest_incr
+)
+
+call "%LATEST_PYTHON%" "%~dp0IBEX_upgrade.py" --kits_icp_dir "%KITS_ICP_PATH%"  %SERVER_BUILD_PREFIX% --quiet %INSTALL_TYPE%
 IF ERRORLEVEL 1 GOTO :ERROR
 
 popd


### PR DESCRIPTION
* Add option to specify prefix to directory used to install latest build from
* Allow this option to be specified via   install_latest-build_only.bat

See ISISComputingGroup/IBEX#4604

This is tested as part of FreddieSystemTests and FreddieIocTests jobs

it could be tested on e.g. demo by running the bat script 