### PR TITLE
Add instructions for configuring IE.

### DIFF
--- a/installation_and_upgrade/ibex_install_utils/install_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/install_tasks.py
@@ -1283,7 +1283,6 @@ class UpgradeTasks(object):
         """
         Restrict access of external websites to address a security vulnerability in Internet Explorer.
         """
-        # For future reference, genie_python can send emails!
         self.prompt.prompt_and_raise_if_not_yes(
             "Configure Internet Explorer to restrict access to the web except for select whitelisted sites:\n"
             "- Open 'Internet Options' (from the gear symbol in the top right corner of the window).\n"

--- a/installation_and_upgrade/ibex_install_utils/install_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/install_tasks.py
@@ -166,6 +166,7 @@ class UpgradeInstrument(object):
         self._upgrade_tasks.remove_seci_shortcuts()
         self._upgrade_tasks.remove_seci_one()
         self._upgrade_tasks.remove_treesize_shortcuts()
+        self._upgrade_tasks.restrict_ie()
 
         self._upgrade_tasks.install_ibex_server(self._should_install_utils())
         self._upgrade_tasks.install_genie_python3()
@@ -226,6 +227,7 @@ class UpgradeInstrument(object):
         self._upgrade_tasks.truncate_database()
         self._upgrade_tasks.remove_seci_shortcuts()
         self._upgrade_tasks.remove_treesize_shortcuts()
+        self._upgrade_tasks.restrict_ie()
         self._upgrade_tasks.install_ibex_server(self._should_install_utils())
         self._upgrade_tasks.install_genie_python3()
         self._upgrade_tasks.install_mysql()
@@ -1020,6 +1022,8 @@ class UpgradeTasks(object):
             "If the font cannot be seen in the genie_python.bat change default terminal colours to white on black.")
         self.prompt.prompt_and_raise_if_not_yes(
             "Verify that the current configuration is consistent with the system prior to upgrade")
+        self.prompt.prompt_and_raise_if_not_yes(
+            "Verify that all the links from the 'Weblinks' perspective still work (i.e. the address gets resolved)")
 
     @task("Server release tests")
     def perform_server_tests(self):
@@ -1273,3 +1277,16 @@ class UpgradeTasks(object):
         except (OSError, IOError):
             self.prompt.prompt_and_raise_if_not_yes("Please manually copy file from '{}' to '{}'"
                                                     .format(from_path, to_path))
+
+    @task("Restrict Internet Explorer")
+    def restrict_ie(self):
+        """
+        Restrict access of external websites to address a security vulnerability in Internet Explorer.
+        """
+        # For future reference, genie_python can send emails!
+        self.prompt.prompt_and_raise_if_not_yes(
+            "Configure Internet Explorer to restrict access to the web except for select whitelisted sites:\n"
+            "- Open 'Internet Options' (from the gear symbol in the top right corner of the window).\n"
+            "- Go to the 'Connections' tab and open 'Lan Settings'\n"
+            "- Check 'Use Automatic configuration script' and enter http://dataweb.isis.rl.ac.uk/proxy.pac for 'Address'\n"
+            "- Click 'Ok' on all dialogs.")


### PR DESCRIPTION
Added a step to the deploy / install script with instructions on how to configure IE to use a custom proxy configuration that blocks all traffic, except for selected whitelisted sites.

Ticket: https://github.com/ISISComputingGroup/IBEX/issues/5112