### PR TITLE
Update install tasks

### DIFF
--- a/installation_and_upgrade/ibex_install_utils/install_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/install_tasks.py
@@ -876,7 +876,7 @@ class UpgradeTasks(object):
 
         # Restart to pick up new my.ini
         admin_commands = AdminCommandBuilder()
-        admin_commands.add_command("sc", "stop MYSQL80")
+        admin_commands.add_command("sc", "stop MYSQL80", expected_return_val=None)
         # Sleep to wait for service to stop so we can restart it.
         admin_commands.add_command("ping", "-n 10 127.0.0.1 >nul", expected_return_val=None)
         admin_commands.add_command("sc", "start MYSQL80")


### PR DESCRIPTION
Added a flag to ignore errors when stopping MYSQL service as part of the update to the latest version. This stops the script from falling over when trying to stop MYSQL when it was not running in the first place