### PR TITLE
Fix IBEX server start

### DIFF
--- a/installation_and_upgrade/instrument_deploy.bat
+++ b/installation_and_upgrade/instrument_deploy.bat
@@ -14,11 +14,13 @@ set "START_IBEX=C:\Instrument\Apps\EPICS\start_ibex_server"
 
 IF EXIST "C:\Instrument\Apps\EPICS" (
   call C:\Instrument\Apps\EPICS\config_env.bat
+  SETLOCAL
   set PYTHONDIR=%LATEST_PYTHON_DIR%
   set PYTHONHOME=%LATEST_PYTHON_DIR%
   set PYTHONPATH=%LATEST_PYTHON_DIR%
   call "%LATEST_PYTHON%" "%~dp0IBEX_upgrade.py" --release_dir "%SOURCE%" --release_suffix "%SUFFIX%" --confirm_step instrument_deploy_pre_stop
   IF ERRORLEVEL 1 EXIT /b %errorlevel%
+  ENDLOCAL
   start /wait cmd /c "%STOP_IBEX%")
 )
 


### PR DESCRIPTION
There is an error in the deploy script which means that the automated start of the IBEX server between update and post-deploy system tests does not work properly.

The reason was that python environment variables were set for the install which were overwriting the values set by config_env. These changes confine this assignment to a local context which should fix the issue.