### PR TITLE
Use local python

### DIFF
--- a/installation_and_upgrade/instrument_deploy.bat
+++ b/installation_and_upgrade/instrument_deploy.bat
@@ -36,5 +36,6 @@ ENDLOCAL
 
 start /wait cmd /c "%START_IBEX%"
 
-call "%LATEST_PYTHON%" "%~dp0IBEX_upgrade.py" --release_dir "%SOURCE%" --release_suffix "%SUFFIX%" --confirm_step instrument_deploy_post_start
+REM python should be installed correctly at this point, so use local python
+call "C:\Instrument\Apps\Python\python.exe" "%~dp0IBEX_upgrade.py" --release_dir "%SOURCE%" --release_suffix "%SUFFIX%" --confirm_step instrument_deploy_post_start
 IF ERRORLEVEL 1 EXIT /b %errorlevel%


### PR DESCRIPTION
Use local python to run `instrument_deploy_post_start`

Ticket: https://github.com/ISISComputingGroup/IBEX/issues/5254

Acceptance criteria:
- [ ] After a deployment, genie_python methods in the scripting perspective called from the local deployment, not a network share.