### PR TITLE
Ticket4776 fix alarm database

### DIFF
--- a/installation_and_upgrade/ibex_install_utils/install_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/install_tasks.py
@@ -231,6 +231,7 @@ class UpgradeInstrument(object):
         self._upgrade_tasks.backup_old_directories()
         self._upgrade_tasks.backup_database()
         self._upgrade_tasks.truncate_database()
+        self._upgrade_tasks.truncate_alarms_table()
         self._upgrade_tasks.remove_seci_shortcuts()
         self._upgrade_tasks.remove_treesize_shortcuts()
         self._upgrade_tasks.restrict_ie()
@@ -266,6 +267,7 @@ class UpgradeInstrument(object):
         """
         self._upgrade_tasks.backup_database()
         self._upgrade_tasks.truncate_database()
+        self._upgrade_tasks.truncate_alarms_table()
 
     def run_force_upgrade_mysql(self):
         """:key


### PR DESCRIPTION
### Description of work

Adds a fix for instruments which cannot start their alarms server. A new upgrade step truncates the alarms table to fix the issue.

### Ticket
https://github.com/ISISComputingGroup/IBEX/issues/4776

### Acceptance criteria
- [x] New upgrade step truncates alarms database
- [x] Performing this upgrade step fixes the issue with the alarm server on an instrument
- [x] Existing truncate_database step still functions