### PR TITLE
Fixes email template if version is not known

### DIFF
--- a/installation_and_upgrade/IBEX_upgrade.py
+++ b/installation_and_upgrade/IBEX_upgrade.py
@@ -66,6 +66,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     client_e4_dir = args.client_e4_dir
+    current_client_version = None
     if args.release_dir is not None:
         current_release_dir = os.path.join(args.release_dir, _get_latest_release_path(args.release_dir))
         current_client_version = _get_latest_release_path(args.release_dir).split("\\")[-1]
@@ -103,7 +104,8 @@ if __name__ == "__main__":
 
     try:
         prompt = UserPrompt(args.quiet, args.confirm_step)
-        upgrade_instrument = UpgradeInstrument(prompt, server_dir, client_dir, client_e4_dir, genie_python3_dir, current_client_version)
+        upgrade_instrument = UpgradeInstrument(prompt, server_dir, client_dir, client_e4_dir, genie_python3_dir,
+                                               current_client_version)
         upgrade_function = UPGRADE_TYPES[args.deployment_type][0]
         upgrade_function(upgrade_instrument)
 

--- a/installation_and_upgrade/ibex_install_utils/install_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/install_tasks.py
@@ -1166,13 +1166,17 @@ class UpgradeTasks(object):
         Inform instrument scientists that the machine has been upgraded.
         """
         # For future reference, genie_python can send emails!
-        self.prompt.prompt_and_raise_if_not_yes(
-            "Please send the following email to your instrument scientists:\n"+\
-            "Hello,\n\nWe have finished the upgrade of {} to IBEX {}.".format(self._machine_name, self._ibex_version)+\
-            "The release notes for this are at the following link: "
-            "https://github.com/ISISComputingGroup/IBEX/wiki/Release-Notes-v{}\n\n".format(self._ibex_version)+\
-            "Please let us know if you have any queries or find any problems with the upgrade.\n\n"+\
-            "Thank you,\n\n<your name>")
+        ibex_version = self._ibex_version if self._ibex_version is not None else "<Insert version number here>"
+        email_template = """Please send the following email to your instrument scientists:
+            Hello,
+            We have finished the upgrade of {machine_name} to IBEX {ibex_version}.
+            The release notes for this are at the following link: https://github.com/ISISComputingGroup/IBEX/wiki/Release-Notes-v{ibex_version}
+            
+            Please let us know if you have any queries or find any problems with the upgrade.
+            Thank you,
+            <your name>""".format(machine_name=self._machine_name, ibex_version=ibex_version)
+
+        self.prompt.prompt_and_raise_if_not_yes(email_template)
 
     @task("Apply changes in release notes")
     def apply_changes_noted_in_release_notes(self):


### PR DESCRIPTION
Fixes issue seen in builds e.g. http://epics-jenkins.isis.rl.ac.uk/view/WallDisplay/job/System_Tests_IOCs/4792/console where there is no default for current version number. This adds in `None` as the default and prints a sensible email format based on that