### PR TITLE
Ticket 3928: Update ICP during deploy

### DIFF
--- a/installation_and_upgrade/IBEX_upgrade.py
+++ b/installation_and_upgrade/IBEX_upgrade.py
@@ -10,19 +10,7 @@ import sys
 from ibex_install_utils.install_tasks import UpgradeInstrument, UPGRADE_TYPES
 from ibex_install_utils.exceptions import UserStop, ErrorInTask
 from ibex_install_utils.user_prompt import UserPrompt
-
-
-def _get_latest_directory_path(build_dir, build_prefix, directory_above_build_num=None, ):
-    latest_build_path = os.path.join(build_dir, "LATEST_BUILD.txt")
-    build_num = None
-    for line in open(latest_build_path):
-        build_num = line.strip()
-    if build_num is None or build_num == "":
-        print("Latest build num unknown. Cannot read it from '{0}'".format(latest_build_path))
-        sys.exit(3)
-    if directory_above_build_num is None:
-        return os.path.join(build_dir, "{}{}".format(build_prefix, build_num))
-    return os.path.join(build_dir, "{}{}".format(build_prefix, build_num), directory_above_build_num)
+from ibex_install_utils.file_utils import get_latest_directory_path
 
 
 def _get_latest_release_path(release_dir):
@@ -81,16 +69,21 @@ if __name__ == "__main__":
             epics_build_dir = os.path.join(args.kits_icp_dir, "EPICS", args.server_build_prefix+"_win7_x64")
         else:
             epics_build_dir = os.path.join(args.kits_icp_dir, "EPICS", args.server_build_prefix+"_CLEAN_win7_x64")
-        server_dir = _get_latest_directory_path(epics_build_dir, "BUILD-", "EPICS")
 
-        client_build_dir = os.path.join(args.kits_icp_dir, "Client")
-        client_dir = _get_latest_directory_path(client_build_dir, "BUILD")
+        try:
+            server_dir = get_latest_directory_path(epics_build_dir, "BUILD-", "EPICS")
 
-        client_e4_build_dir = os.path.join(args.kits_icp_dir, "Client_E4")
-        client_e4_dir = _get_latest_directory_path(client_e4_build_dir, "BUILD")
+            client_build_dir = os.path.join(args.kits_icp_dir, "Client")
+            client_dir = get_latest_directory_path(client_build_dir, "BUILD")
 
-        genie_python3_build_dir = os.path.join(args.kits_icp_dir, "genie_python_3")
-        genie_python3_dir = _get_latest_directory_path(genie_python3_build_dir, "BUILD-")
+            client_e4_build_dir = os.path.join(args.kits_icp_dir, "Client_E4")
+            client_e4_dir = get_latest_directory_path(client_e4_build_dir, "BUILD")
+
+            genie_python3_build_dir = os.path.join(args.kits_icp_dir, "genie_python_3")
+            genie_python3_dir = get_latest_directory_path(genie_python3_build_dir, "BUILD-")
+        except IOError as e:
+            print(e.message)
+            sys.exit(3)
 
     elif args.server_dir is not None and args.client_dir is not None and args.genie_python3_dir is not None and \
             args.client_e4_dir is not None:

--- a/installation_and_upgrade/ibex_install_utils/file_utils.py
+++ b/installation_and_upgrade/ibex_install_utils/file_utils.py
@@ -5,10 +5,21 @@ Filesystem utility classes
 import os
 import shutil
 import time
-
 from ibex_install_utils.exceptions import UserStop
 
 LABVIEW_DAE_DIR = os.path.join("C:\\", "LabVIEW modules", "DAE")
+
+
+def get_latest_directory_path(build_dir, build_prefix, directory_above_build_num=None, ):
+    latest_build_path = os.path.join(build_dir, "LATEST_BUILD.txt")
+    build_num = None
+    for line in open(latest_build_path):
+        build_num = line.strip()
+    if build_num is None or build_num == "":
+        raise IOError("Latest build num unknown. Cannot read it from '{0}'".format(latest_build_path))
+    if directory_above_build_num is None:
+        return os.path.join(build_dir, "{}{}".format(build_prefix, build_num))
+    return os.path.join(build_dir, "{}{}".format(build_prefix, build_num), directory_above_build_num)
 
 
 class FileUtils(object):

--- a/installation_and_upgrade/ibex_install_utils/file_utils.py
+++ b/installation_and_upgrade/ibex_install_utils/file_utils.py
@@ -3,11 +3,12 @@ Filesystem utility classes
 """
 
 import os
-import time
 import shutil
 import time
 
 from ibex_install_utils.exceptions import UserStop
+
+LABVIEW_DAE_DIR = os.path.join("C:\\", "LabVIEW modules", "DAE")
 
 
 class FileUtils(object):

--- a/installation_and_upgrade/ibex_install_utils/install_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/install_tasks.py
@@ -5,7 +5,7 @@ from __future__ import division, unicode_literals, print_function
 
 import os
 
-from ibex_install_utils.file_utils import FileUtils
+from ibex_install_utils.file_utils import FileUtils, LABVIEW_DAE_DIR
 from ibex_install_utils.tasks.backup_tasks import BackupTasks
 from ibex_install_utils.tasks.client_tasks import ClientTasks
 from ibex_install_utils.tasks.mysql_tasks import MysqlTasks
@@ -13,8 +13,6 @@ from ibex_install_utils.tasks.python_tasks import PythonTasks
 from ibex_install_utils.tasks.server_tasks import ServerTasks
 from ibex_install_utils.tasks.system_tasks import SystemTasks
 from ibex_install_utils.tasks.vhd_tasks import VHDTasks
-
-LABVIEW_DAE_DIR = os.path.join("C:\\", "LabVIEW modules", "DAE")
 
 
 class UpgradeInstrument(object):
@@ -56,13 +54,13 @@ class UpgradeInstrument(object):
             user_prompt, server_source_dir, client_source_dir, client_e4_source_dir, genie_python3_dir, ibex_version, file_utils)
 
     @staticmethod
-    def _should_install_utils():
+    def icp_in_labview_modules():
         """
-        Condition on which to install ibex utils (ICP_Binaries)
+        Condition on which to install ICP_Binaries or
 
-        :return: True if utils should be installed, False otherwise
+        :return: True if the ICP is installed in labview modules, False otherwise
         """
-        return not os.path.exists(LABVIEW_DAE_DIR)
+        return os.path.exists(LABVIEW_DAE_DIR)
 
     def run_test_update(self):
         """
@@ -74,8 +72,8 @@ class UpgradeInstrument(object):
         self._system_tasks.clean_up_desktop_ibex_training_folder()
         self._server_tasks.remove_settings()
         self._server_tasks.install_settings()
-        self._server_tasks.install_ibex_server(self._should_install_utils())
-        self._server_tasks.patch_isisdae()
+        self._server_tasks.install_ibex_server()
+        self._server_tasks.update_icp(self.icp_in_labview_modules())
         self._python_tasks.install_genie_python3()
         self._client_tasks.install_ibex_client()
         self._system_tasks.upgrade_notepad_pp()
@@ -90,8 +88,8 @@ class UpgradeInstrument(object):
 
         self._system_tasks.user_confirm_upgrade_type_on_machine('Client/Server Machine')
         self._backup_tasks.remove_old_ibex()
-        self._server_tasks.install_ibex_server(self._should_install_utils())
-        self._server_tasks.patch_isisdae()
+        self._server_tasks.install_ibex_server()
+        self._server_tasks.update_icp(self.icp_in_labview_modules())
         self._python_tasks.install_genie_python3()
         self._client_tasks.install_e4_ibex_client()
         self._server_tasks.upgrade_instrument_configuration()
@@ -120,8 +118,8 @@ class UpgradeInstrument(object):
         self._system_tasks.remove_treesize_shortcuts()
         self._system_tasks.restrict_ie()
 
-        self._server_tasks.install_ibex_server(self._should_install_utils())
-        self._server_tasks.patch_isisdae()
+        self._server_tasks.install_ibex_server()
+        self._server_tasks.update_icp(self.icp_in_labview_modules())
         self._python_tasks.install_genie_python3()
         self._mysql_tasks.install_mysql()
         self._client_tasks.install_ibex_client()
@@ -179,8 +177,8 @@ class UpgradeInstrument(object):
         self._backup_tasks.backup_old_directories()
         self._mysql_tasks.backup_database()
         self._mysql_tasks.truncate_database()
-        self._server_tasks.install_ibex_server(self._should_install_utils())
-        self._server_tasks.patch_isisdae()
+        self._server_tasks.install_ibex_server()
+        self._server_tasks.update_icp(self.icp_in_labview_modules())
         self._python_tasks.install_genie_python3()
         self._mysql_tasks.install_mysql()
 
@@ -238,7 +236,6 @@ class UpgradeInstrument(object):
         self._vhd_tasks.request_mount_vhds()
         try:
             self._server_tasks.install_ibex_server(True)
-            self._server_tasks.patch_isisdae()
             self._python_tasks.install_genie_python3()
             self._mysql_tasks.install_mysql_for_vhd()
             self._client_tasks.install_e4_ibex_client()

--- a/installation_and_upgrade/ibex_install_utils/install_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/install_tasks.py
@@ -235,7 +235,7 @@ class UpgradeInstrument(object):
         self._vhd_tasks.copy_vhds_to_local_area()
         self._vhd_tasks.request_mount_vhds()
         try:
-            self._server_tasks.install_ibex_server(True)
+            self._server_tasks.install_ibex_server()
             self._python_tasks.install_genie_python3()
             self._mysql_tasks.install_mysql_for_vhd()
             self._client_tasks.install_e4_ibex_client()

--- a/installation_and_upgrade/ibex_install_utils/tasks/server_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/server_tasks.py
@@ -359,9 +359,9 @@ class ServerTasks(BaseTasks):
             self.prompt.confirm_step("Install into EPICS/ICP_Binaries")
             RunProcess(EPICS_PATH, "create_icp_binaries.bat").run()
 
-            icp_exe_path = EPICS_PATH, "ICP_Binaries", "isisdae", "x64", "Release"
-            register_icp_commands.add(os.path.join(icp_exe_path, "isisicp.exe"), r"/RegServer")
-            register_icp_commands.add(os.path.join(icp_exe_path, "isisdatasvr.exe"), r"/RegServer")
+            icp_exe_path = os.path.join(EPICS_PATH, "ICP_Binaries", "isisdae", "x64", "Release")
+            register_icp_commands.add_command(os.path.join(icp_exe_path, "isisicp.exe"), r"/RegServer")
+            register_icp_commands.add_command(os.path.join(icp_exe_path, "isisdatasvr.exe"), r"/RegServer")
 
         print("ICP updated successfully, registering ICP")
         register_icp_commands.run_all()

--- a/installation_and_upgrade/ibex_install_utils/tasks/server_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/server_tasks.py
@@ -331,6 +331,21 @@ class ServerTasks(BaseTasks):
     def update_icp(self, icp_in_labview_modules):
         register_icp_commands = AdminCommandBuilder()
 
+        if BaseTasks._get_machine_name() == "NDEMUONFE":
+            print("NDEMUONFE requires an old IOC")
+            for filename in os.listdir(RELEASE_5_5_0_ISISDAE_DIR):
+                if filename.lower() == "isisdae-ioc-01.exe":
+                    continue
+
+                source_path = os.path.join(RELEASE_5_5_0_ISISDAE_DIR, filename)
+                dest_path = os.path.join(EPICS_PATH, "ioc", "master", "ISISDAE", "bin", "windows-x64", filename)
+
+                print("Patching {}".format(filename))
+                if os.path.exists(dest_path):
+                    os.remove(dest_path)
+                shutil.copy2(source_path, dest_path)
+            print("ISISDAE successfully patched")
+
         if icp_in_labview_modules:
             config_filepath = os.path.join(LABVIEW_DAE_DIR, "icp_config.xml")
             root = lxml.etree.parse(config_filepath)

--- a/installation_and_upgrade/ibex_install_utils/tasks/server_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/server_tasks.py
@@ -369,10 +369,10 @@ class ServerTasks(BaseTasks):
             icp_path = get_latest_directory_path(os.path.join(INST_SHARE_AREA, "kits$", "CompGroup", "ICP", "ISISICP",
                                                               "DAE{}".format(dae_type)), "")
 
-            RunProcess(os.getcwd(), "update_inst.cmd", executable_directory=icp_path).run()
+            RunProcess(os.getcwd(), "update_inst.cmd", prog_args=["NOINT"], executable_directory=icp_path).run()
 
-            register_icp_commands.add_command(os.path.join(LABVIEW_DAE_DIR, "register_programs.cmd"), "",
-                                              expected_return_val=None)
+            register_icp_commands.add_command('cd "{}" && register_programs.cmd'.format(LABVIEW_DAE_DIR),
+                                              "Release NOINT", expected_return_val=None)
         else:
             self.prompt.confirm_step("Install into EPICS/ICP_Binaries")
             RunProcess(EPICS_PATH, "create_icp_binaries.bat").run()

--- a/installation_and_upgrade/ibex_install_utils/tasks/server_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/server_tasks.py
@@ -19,7 +19,7 @@ from ibex_install_utils.task import task
 from ibex_install_utils.tasks import BaseTasks
 from ibex_install_utils.tasks.common_paths import APPS_BASE_DIR, INSTRUMENT_BASE_DIR, VAR_DIR, EPICS_PATH, \
     SETTINGS_CONFIG_PATH, SETTINGS_CONFIG_FOLDER, INST_SHARE_AREA
-from ibex_install_utils.file_utils import FileUtils, LABVIEW_DAE_DIR
+from ibex_install_utils.file_utils import FileUtils, LABVIEW_DAE_DIR, get_latest_directory_path
 
 CONFIG_UPGRADE_SCRIPT_DIR = os.path.join(EPICS_PATH, "misc", "upgrade", "master")
 
@@ -337,14 +337,21 @@ class ServerTasks(BaseTasks):
                 print("Failed to find DAE_type ({}), not installing ICP".format(e.message))
                 return
             # If the ICP is talking to a DAE2 it's DAEType will be 1 or 2, if it's talking to a DAE3 it will be 3 or 4
-            if DAE_type == 1 or DAE_type == 2:
+            if DAE_type in [1, 2]:
                 DAE_type = 2
-            elif DAE_type == 3 or DAE_type == 4:
+            elif DAE_type in [3, 4]:
                 DAE_type = 3
             else:
                 print("DAE type {} not recognised, not installing ICP".format(DAE_type))
                 return
-            self.prompt.confirm_step("upgrade DAE{} type ICP found in labview modules?".format(DAE_type))
+            self.prompt.confirm_step("Upgrade DAE{} type ICP found in Labview Modules".format(DAE_type))
+            ICP_path = get_latest_directory_path(os.path.join(INST_SHARE_AREA, "kits$", "CompGroup", "ICP", "ISISICP",
+                                                              "DAE{}".format(DAE_type)), "")
+
+            RunProcess(os.getcwd(), "update_inst.cmd", executable_directory=ICP_path).run()
+
+            print("ICP updated successfully, registering ICP")
         else:
-            self.prompt.confirm_step("install into EPICS/ICP_Binaries?")
+            self.prompt.confirm_step("Install into EPICS/ICP_Binaries")
             RunProcess(EPICS_PATH, "create_icp_binaries.bat").run()
+


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/3928

To test:
1. Start your instrument
1. Create the folder `C:\Labview Modules\DAE` and unzip [icp_config.zip](https://github.com/ISISComputingGroup/ibex_utils/files/4912788/icp_config.zip) into it
1. Console into `ISISDAE`, toggle autorestart to off and kill the IOC (keep the console open)
1. In taskmanager kill `ISISICP` and confirm it doesn't restart itself (keep task manager open)
1. Run the upgrade script with `python IBEX_upgrade.py --kits_icp_dir \\isis.cclrc.ac.uk\inst$\Kits$\CompGroup\ICP\ --confirm_step instrument_deploy_main`
1. Reply `N` to the first 6 steps then `Y` to the update ICP step
1. Confirm the script copies from the DAE2 directory
1. After copy (and after you've entered admin credentials for the register) start the `ISISDAE` console
1. In task manager rightclick on ISISICP and look at the properties, confirm it is being run from inside the `Labview Modules` directory
1. Modify `icp_config.xml` to have DAEType of 3, delete the contents of `C:\Labview Modules\DAE\service`, repeat steps 2-8 but instead confirming that the copy happens from the DAE3 directory
1. Rename `C:\Labview Modules\DAE\` and repeat steps 2-8 but confirm that a new ICP is copied into `C:\Instrument\EPICS\ICP_binaries` and it is running from there

