### PR TITLE
Ticket 5573: Steps that require genie_python are now done in python 3

### DIFF
--- a/installation_and_upgrade/IBEX_upgrade.py
+++ b/installation_and_upgrade/IBEX_upgrade.py
@@ -29,7 +29,7 @@ def _get_latest_release_path(release_dir):
     regex = re.compile(r'^\d\.\d\.\d$')
 
     releases = [name for name in os.listdir(release_dir) if os.path.isdir(os.path.join(release_dir, name))]
-    releases = filter(regex.match, releases)
+    releases = list(filter(regex.match, releases))
 
     if len(releases) == 0:
         print("Error: No releases found in '{0}'".format(release_dir))
@@ -70,7 +70,7 @@ if __name__ == "__main__":
     if args.release_dir is not None:
         current_release_dir = os.path.join(args.release_dir, _get_latest_release_path(args.release_dir))
         current_client_version = _get_latest_release_path(args.release_dir).split("\\")[-1]
-        if args.release_suffix is not "":
+        if args.release_suffix != "":
             current_release_dir += "-{}".format(args.release_suffix)
         server_dir = os.path.join(current_release_dir, "EPICS")
         client_dir = os.path.join(current_release_dir, "Client")

--- a/installation_and_upgrade/define_latest_genie_python.bat
+++ b/installation_and_upgrade/define_latest_genie_python.bat
@@ -5,10 +5,16 @@ REM   LATEST_PYTHON is set to a version on genie_python that can be run
 
 set "KITS_ICP_PATH=\\isis.cclrc.ac.uk\inst$\Kits$\CompGroup\ICP"
 
-if exist "%KITS_ICP_PATH%\genie_python\LATEST_BUILD.txt" (
-	for /f %%i in ( %KITS_ICP_PATH%\genie_python\LATEST_BUILD.txt ) do (
-	    set LATEST_PYTHON_DIR=%KITS_ICP_PATH%\genie_python\BUILD-%%i\Python\
-	    set LATEST_PYTHON=%KITS_ICP_PATH%\genie_python\BUILD-%%i\Python\python.exe
+if "%1" == "3" (
+    set "GENIE_DIR=%KITS_ICP_PATH%\genie_python_3"
+) else (
+    set "GENIE_DIR=%KITS_ICP_PATH%\genie_python"
+)
+
+if exist "%GENIE_DIR%\LATEST_BUILD.txt" (
+	for /f %%i in ( %GENIE_DIR%\LATEST_BUILD.txt ) do (
+	    set LATEST_PYTHON_DIR=%GENIE_DIR%\BUILD-%%i\Python\
+	    set LATEST_PYTHON=%GENIE_DIR%\BUILD-%%i\Python\python.exe
 	)
 ) else (
 	@echo Could not access LATEST_BUILD.txt

--- a/installation_and_upgrade/ibex_install_utils/ca_utils.py
+++ b/installation_and_upgrade/ibex_install_utils/ca_utils.py
@@ -3,6 +3,7 @@ import os
 
 import zlib
 
+from genie_python.utilities import dehex_and_decompress
 
 class CaWrapper(object):
     """
@@ -53,7 +54,7 @@ class CaWrapper(object):
         if data is None:
             return None
         else:
-            return json.loads(zlib.decompress(data.decode('hex')))
+            return dehex_and_decompress(data)
 
     def get_blocks(self):
         """

--- a/installation_and_upgrade/ibex_install_utils/motor_params.py
+++ b/installation_and_upgrade/ibex_install_utils/motor_params.py
@@ -6,6 +6,8 @@ load the script into a genie_python console and run as a standard user script.
 import csv
 from genie_python import genie as g
 
+g.set_instrument(None)
+
 VELOCITY_UNITS = "EGU per sec"
 
 PV, AXIS_NAME = "PV", "Axis Name"

--- a/installation_and_upgrade/ibex_install_utils/tasks/server_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/server_tasks.py
@@ -284,9 +284,7 @@ class ServerTasks(BaseTasks):
         """
         Saves block parameters in a file.
         """
-
         blocks = self._ca.get_blocks()
-
         if blocks is None:
             print("Blockserver unavailable - not archiving.")
         else:

--- a/installation_and_upgrade/instrument_deploy.bat
+++ b/installation_and_upgrade/instrument_deploy.bat
@@ -1,6 +1,5 @@
 set "SOURCE=\\isis.cclrc.ac.uk\inst$\Kits$\CompGroup\ICP\Releases"
 rem set "RELEASE-SUFFIX="
-call "%~dp0\define_latest_genie_python.bat"
 
 git --version
 
@@ -13,6 +12,8 @@ set "STOP_IBEX=C:\Instrument\Apps\EPICS\stop_ibex_server"
 set "START_IBEX=C:\Instrument\Apps\EPICS\start_ibex_server"
 
 IF EXIST "C:\Instrument\Apps\EPICS" (
+  REM use python 3 for pre stop as requires genie
+  call "%~dp0\define_latest_genie_python.bat" 3
   call C:\Instrument\Apps\EPICS\config_env.bat
   SETLOCAL
   set PYTHONDIR=%LATEST_PYTHON_DIR%
@@ -25,6 +26,7 @@ IF EXIST "C:\Instrument\Apps\EPICS" (
 )
 
 REM Set python as share just for script call
+call "%~dp0\define_latest_genie_python.bat"
 SETLOCAL
 set PYTHONDIR=%LATEST_PYTHON_DIR%
 set PYTHONHOME=%LATEST_PYTHON_DIR%
@@ -37,6 +39,6 @@ ENDLOCAL
 start /wait cmd /c "%START_IBEX%"
 
 REM python should be installed correctly at this point, so use local python
-call "C:\Instrument\Apps\Python\python.exe" "%~dp0IBEX_upgrade.py" --release_dir "%SOURCE%" --release_suffix "%SUFFIX%" --confirm_step instrument_deploy_post_start
+call "C:\Instrument\Apps\Python3\python.exe" "%~dp0IBEX_upgrade.py" --release_dir "%SOURCE%" --release_suffix "%SUFFIX%" --confirm_step instrument_deploy_post_start
 :ERROR
 EXIT /b %errorlevel%


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/5573

Turns out the original issue was caused by the upgrade script trying to run bits of genie_python in python 2. This PR changes those to be run in python 3.

To test do a deploy using `instrument_deploy.bat` and confirm none of the steps fail. 