### PR TITLE
Remove redundant install task

### DIFF
--- a/installation_and_upgrade/ibex_install_utils/install_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/install_tasks.py
@@ -135,7 +135,6 @@ class UpgradeInstrument(object):
         self._server_tasks.configure_motion()
         self._system_tasks.add_nagios_checks()
         self._system_tasks.update_instlist()
-        self._system_tasks.update_web_dashboard()
         self._system_tasks.update_kafka_topics()
         self._system_tasks.put_autostart_script_in_startup_area()
         self._python_tasks.update_script_definitions()

--- a/installation_and_upgrade/ibex_install_utils/tasks/system_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/system_tasks.py
@@ -156,22 +156,6 @@ class SystemTasks(BaseTasks):
         self.prompt.prompt_and_raise_if_not_yes(
             "Add the host name of the instrument to the list saved in the CS:INSTLIST PV")
 
-    @task("Update web dashboard")
-    def update_web_dashboard(self):
-        """
-        Prompt user to add the instrument to the web dashboard
-        """
-        redirect_page = os.path.join("C:", "inetpub", "wwwroot", "DataWeb", "Dashboards", "redirect.html")
-        self.prompt.prompt_and_raise_if_not_yes(
-            "Add the host name of the instrument to NDX_INSTS or ALL_INSTS in webserver.py in the JSON_bourne "
-            "repository.")
-        self.prompt.prompt_and_raise_if_not_yes(
-            "On NDAEXTWEB1, pull the updated code and add a link to the instrument dashboard on the main "
-            "dataweb page under {}".format(redirect_page))
-        self.prompt.prompt_and_raise_if_not_yes(
-            "Restart JSON_bourne on NDAEXTWEB1 when appropriate. "
-            "(WARNING: This will kill all existing sessions!)")
-
     @task("Update kafka topics")
     def update_kafka_topics(self):
         """


### PR DESCRIPTION
The web dashboard now automatically picks up changes to the instrument list, so these steps are no longer required.
This was demonstrated during the install on INTER, which didn't need these steps but does show on the dashboard