### PR TITLE
Calling py3 on instrument update script

### DIFF
--- a/build_tools/purge_archive.bat
+++ b/build_tools/purge_archive.bat
@@ -1,6 +1,6 @@
 setlocal
 REM Remove old builds from the archive
-call "%~dp0..\installation_and_upgrade\define_latest_genie_python.bat"
+call "%~dp0..\installation_and_upgrade\define_latest_genie_python.bat" 3
 set PYTHONUNBUFFERED=TRUE
 call "%LATEST_PYTHON%" "%~dp0purge_archive.py"
 

--- a/installation_and_upgrade/developer_update.bat
+++ b/installation_and_upgrade/developer_update.bat
@@ -1,5 +1,5 @@
 set "SOURCE=\\isis.cclrc.ac.uk\inst$\Kits$\CompGroup\ICP\Releases"
-call "%~dp0\define_latest_genie_python.bat"
+call "%~dp0\define_latest_genie_python.bat" 3
 
 set "STOP_IBEX=C:\Instrument\Apps\EPICS\stop_ibex_server"
 set "START_IBEX=C:\Instrument\Apps\EPICS\start_ibex_server"

--- a/installation_and_upgrade/instrument_deploy.bat
+++ b/installation_and_upgrade/instrument_deploy.bat
@@ -26,7 +26,7 @@ IF EXIST "C:\Instrument\Apps\EPICS" (
 )
 
 REM Set python as share just for script call
-call "%~dp0\define_latest_genie_python.bat"
+call "%~dp0\define_latest_genie_python.bat" 3
 SETLOCAL
 set PYTHONDIR=%LATEST_PYTHON_DIR%
 set PYTHONHOME=%LATEST_PYTHON_DIR%
@@ -39,6 +39,11 @@ ENDLOCAL
 start /wait cmd /c "%START_IBEX%"
 
 REM python should be installed correctly at this point, so use local python
-call "C:\Instrument\Apps\Python3\python.exe" "%~dp0IBEX_upgrade.py" --release_dir "%SOURCE%" --release_suffix "%SUFFIX%" --confirm_step instrument_deploy_post_start
+set LATEST_PYTHON_DIR="C:\Instrument\Apps\Python3\"
+set PYTHONDIR=%LATEST_PYTHON_DIR%
+set PYTHONHOME=%LATEST_PYTHON_DIR%
+set PYTHONPATH=%LATEST_PYTHON_DIR%
+
+call "%LATEST_PYTHON_DIR%python.exe" "%~dp0IBEX_upgrade.py" --release_dir "%SOURCE%" --release_suffix "%SUFFIX%" --confirm_step instrument_deploy_post_start
 :ERROR
 EXIT /b %errorlevel%

--- a/installation_and_upgrade/instrument_install.bat
+++ b/installation_and_upgrade/instrument_install.bat
@@ -1,6 +1,6 @@
 set "SOURCE=\\isis.cclrc.ac.uk\inst$\Kits$\CompGroup\ICP\Releases"
 set "SUFFIX=%1"
-call "%~dp0\define_latest_genie_python.bat"
+call "%~dp0\define_latest_genie_python.bat" 3
 
 git --version
 

--- a/installation_and_upgrade/instrument_install_latest_build_only.bat
+++ b/installation_and_upgrade/instrument_install_latest_build_only.bat
@@ -8,7 +8,7 @@ REM with prefix specified will use {prefix}_win7_x64 and {prefix}_CLEAN_win7_x64
  
 set PYTHONUNBUFFERED=TRUE
 
-call "%~dp0\define_latest_genie_python.bat"
+call "%~dp0\define_latest_genie_python.bat" 3
 
 set "STOP_IBEX=C:\Instrument\Apps\EPICS\stop_ibex_server.bat"
 set "START_IBEX=C:\Instrument\Apps\EPICS\start_ibex_server.bat"

--- a/installation_and_upgrade/instrument_test.bat
+++ b/installation_and_upgrade/instrument_test.bat
@@ -1,5 +1,5 @@
 set "SOURCE=\\isis.cclrc.ac.uk\inst$\Kits$\CompGroup\ICP\Releases"
-call "%~dp0\define_latest_genie_python.bat"
+call "%~dp0\define_latest_genie_python.bat" 3
 
 call "%LATEST_PYTHON%" "%~dp0IBEX_upgrade.py" --release_dir "%SOURCE%" --confirm_step instrument_test
 IF ERRORLEVEL 1 EXIT /b %errorlevel%

--- a/installation_and_upgrade/instrument_update.bat
+++ b/installation_and_upgrade/instrument_update.bat
@@ -4,7 +4,7 @@ set "STOP_IBEX=C:\Instrument\Apps\EPICS\stop_ibex_server"
 set "START_IBEX=C:\Instrument\Apps\EPICS\start_ibex_server"
 IF EXIST "C:\Instrument\Apps\EPICS" (start /wait cmd /c "%STOP_IBEX%")
 
-C:\Instrument\Apps\Python\python.exe IBEX_upgrade.py --release_dir "%SOURCE%" --confirm_step instrument_update
+C:\Instrument\Apps\Python3\python.exe IBEX_upgrade.py --release_dir "%SOURCE%" --confirm_step instrument_update
 IF ERRORLEVEL 1 exit /b %errorlevel%
 
 start /wait cmd /c "%START_IBEX%"

--- a/installation_and_upgrade/instrument_update.bat
+++ b/installation_and_upgrade/instrument_update.bat
@@ -1,10 +1,11 @@
+call "%~dp0\define_latest_genie_python.bat"
 set "SOURCE=\\isis.cclrc.ac.uk\inst$\Kits$\CompGroup\ICP\Releases\4.0.0"
 
 set "STOP_IBEX=C:\Instrument\Apps\EPICS\stop_ibex_server"
 set "START_IBEX=C:\Instrument\Apps\EPICS\start_ibex_server"
 IF EXIST "C:\Instrument\Apps\EPICS" (start /wait cmd /c "%STOP_IBEX%")
 
-C:\Instrument\Apps\Python3\python.exe IBEX_upgrade.py --release_dir "%SOURCE%" --confirm_step instrument_update
+call "%LATEST_PYTHON%" "%~dp0IBEX_upgrade.py" --release_dir "%SOURCE%" --confirm_step instrument_update
 IF ERRORLEVEL 1 exit /b %errorlevel%
 
 start /wait cmd /c "%START_IBEX%"

--- a/installation_and_upgrade/instrument_update.bat
+++ b/installation_and_upgrade/instrument_update.bat
@@ -1,4 +1,4 @@
-call "%~dp0\define_latest_genie_python.bat"
+call "%~dp0\define_latest_genie_python.bat" 3
 set "SOURCE=\\isis.cclrc.ac.uk\inst$\Kits$\CompGroup\ICP\Releases\4.0.0"
 
 set "STOP_IBEX=C:\Instrument\Apps\EPICS\stop_ibex_server"

--- a/installation_and_upgrade/truncate_database.bat
+++ b/installation_and_upgrade/truncate_database.bat
@@ -1,5 +1,5 @@
 set "SOURCE=\\isis.cclrc.ac.uk\inst$\Kits$\CompGroup\ICP\Releases"
-call "%~dp0\define_latest_genie_python.bat"
+call "%~dp0\define_latest_genie_python.bat" 3
 
 git --version
 

--- a/installation_and_upgrade/upgrade_mysql.bat
+++ b/installation_and_upgrade/upgrade_mysql.bat
@@ -1,5 +1,5 @@
 set "SOURCE=\\isis.cclrc.ac.uk\inst$\Kits$\CompGroup\ICP\Releases"
-call "%~dp0\define_latest_genie_python.bat"
+call "%~dp0\define_latest_genie_python.bat" 3
 
 set "STOP_IBEX=C:\Instrument\Apps\EPICS\stop_ibex_server"
 set "START_IBEX=C:\Instrument\Apps\EPICS\start_ibex_server"

--- a/installation_and_upgrade/vhd_build.bat
+++ b/installation_and_upgrade/vhd_build.bat
@@ -1,6 +1,6 @@
 set PYTHONUNBUFFERED=1
 set "SOURCE=\\isis.cclrc.ac.uk\inst$\Kits$\CompGroup\ICP\Releases"
-call "%~dp0\define_latest_genie_python.bat"
+call "%~dp0\define_latest_genie_python.bat" 3
 
 IF EXIST "C:\Instrument\Apps\EPICS\stop_ibex_server.bat" (
   start /wait cmd /c "C:\Instrument\Apps\EPICS\stop_ibex_server.bat"


### PR DESCRIPTION
Calls python3 instead of python2 when running the instrument update batch script. Hopefully this should fix the system test builds on Jenkins
