### PR TITLE
Fix installation and upgrade imports

### DIFF
--- a/installation_and_upgrade/IBEX_upgrade.py
+++ b/installation_and_upgrade/IBEX_upgrade.py
@@ -7,10 +7,10 @@ import os
 import re
 import sys
 
-from installation_and_upgrade.ibex_install_utils.install_tasks import UpgradeInstrument, UPGRADE_TYPES
-from installation_and_upgrade.ibex_install_utils.exceptions import UserStop, ErrorInTask
-from installation_and_upgrade.ibex_install_utils.user_prompt import UserPrompt
-from installation_and_upgrade.ibex_install_utils.file_utils import get_latest_directory_path
+from ibex_install_utils.install_tasks import UpgradeInstrument, UPGRADE_TYPES
+from ibex_install_utils.exceptions import UserStop, ErrorInTask
+from ibex_install_utils.user_prompt import UserPrompt
+from ibex_install_utils.file_utils import get_latest_directory_path
 
 
 def _get_latest_release_path(release_dir):

--- a/installation_and_upgrade/ibex_install_utils/file_utils.py
+++ b/installation_and_upgrade/ibex_install_utils/file_utils.py
@@ -5,7 +5,7 @@ Filesystem utility classes
 import os
 import shutil
 import time
-from installation_and_upgrade.ibex_install_utils.exceptions import UserStop
+from ibex_install_utils.exceptions import UserStop
 
 LABVIEW_DAE_DIR = os.path.join("C:\\", "LabVIEW modules", "DAE")
 

--- a/installation_and_upgrade/ibex_install_utils/install_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/install_tasks.py
@@ -4,14 +4,14 @@ Tasks associated with install
 
 import os
 
-from installation_and_upgrade.ibex_install_utils.file_utils import FileUtils, LABVIEW_DAE_DIR
-from installation_and_upgrade.ibex_install_utils.tasks.backup_tasks import BackupTasks
-from installation_and_upgrade.ibex_install_utils.tasks.client_tasks import ClientTasks
-from installation_and_upgrade.ibex_install_utils.tasks.mysql_tasks import MysqlTasks
-from installation_and_upgrade.ibex_install_utils.tasks.python_tasks import PythonTasks
-from installation_and_upgrade.ibex_install_utils.tasks.server_tasks import ServerTasks
-from installation_and_upgrade.ibex_install_utils.tasks.system_tasks import SystemTasks
-from installation_and_upgrade.ibex_install_utils.tasks.vhd_tasks import VHDTasks
+from ibex_install_utils.file_utils import FileUtils, LABVIEW_DAE_DIR
+from ibex_install_utils.tasks.backup_tasks import BackupTasks
+from ibex_install_utils.tasks.client_tasks import ClientTasks
+from ibex_install_utils.tasks.mysql_tasks import MysqlTasks
+from ibex_install_utils.tasks.python_tasks import PythonTasks
+from ibex_install_utils.tasks.server_tasks import ServerTasks
+from ibex_install_utils.tasks.system_tasks import SystemTasks
+from ibex_install_utils.tasks.vhd_tasks import VHDTasks
 
 
 class UpgradeInstrument:

--- a/installation_and_upgrade/ibex_install_utils/motor_params.py
+++ b/installation_and_upgrade/ibex_install_utils/motor_params.py
@@ -6,7 +6,7 @@ load the script into a genie_python console and run as a standard user script.
 import csv
 from genie_python import genie as g
 
-g.set_instrument(None)
+g.set_instrument(None, import_instrument_init=False)
 
 VELOCITY_UNITS = "EGU per sec"
 

--- a/installation_and_upgrade/ibex_install_utils/run_process.py
+++ b/installation_and_upgrade/ibex_install_utils/run_process.py
@@ -5,7 +5,7 @@ Running processes infrastructure.
 import os
 import subprocess
 
-from installation_and_upgrade.ibex_install_utils.exceptions import ErrorInRun
+from ibex_install_utils.exceptions import ErrorInRun
 
 
 class RunProcess:

--- a/installation_and_upgrade/ibex_install_utils/task.py
+++ b/installation_and_upgrade/ibex_install_utils/task.py
@@ -3,8 +3,8 @@ Task infrastructure.
 """
 import traceback
 
-from installation_and_upgrade.ibex_install_utils.exceptions import UserStop, ErrorInTask
-from installation_and_upgrade.ibex_install_utils.user_prompt import UserPrompt
+from ibex_install_utils.exceptions import UserStop, ErrorInTask
+from ibex_install_utils.user_prompt import UserPrompt
 
 
 def _run_task_to_completion(task_name, prompt, self_decorated_method, func, args, kwargs):

--- a/installation_and_upgrade/ibex_install_utils/tasks/__init__.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/__init__.py
@@ -2,9 +2,9 @@ import os
 import socket
 from datetime import date
 
-from installation_and_upgrade.ibex_install_utils.ca_utils import CaWrapper
-from installation_and_upgrade.ibex_install_utils.file_utils import FileUtils
-from installation_and_upgrade.ibex_install_utils.tasks.common_paths import BACKUP_DIR, BACKUP_DATA_DIR
+from ibex_install_utils.ca_utils import CaWrapper
+from ibex_install_utils.file_utils import FileUtils
+from ibex_install_utils.tasks.common_paths import BACKUP_DIR, BACKUP_DATA_DIR
 
 
 class BaseTasks:

--- a/installation_and_upgrade/ibex_install_utils/tasks/backup_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/backup_tasks.py
@@ -2,9 +2,9 @@ import os
 import shutil
 
 
-from installation_and_upgrade.ibex_install_utils.task import task
-from installation_and_upgrade.ibex_install_utils.tasks import BaseTasks
-from installation_and_upgrade.ibex_install_utils.tasks.common_paths import INSTRUMENT_BASE_DIR, BACKUP_DATA_DIR, BACKUP_DIR, EPICS_PATH, \
+from ibex_install_utils.task import task
+from ibex_install_utils.tasks import BaseTasks
+from ibex_install_utils.tasks.common_paths import INSTRUMENT_BASE_DIR, BACKUP_DATA_DIR, BACKUP_DIR, EPICS_PATH, \
     PYTHON_PATH, PYTHON_3_PATH, EPICS_UTILS_PATH, GUI_PATH, GUI_PATH_E4
 
 ALL_INSTALL_DIRECTORIES = (EPICS_PATH, PYTHON_PATH, PYTHON_3_PATH, GUI_PATH, GUI_PATH_E4, EPICS_UTILS_PATH)

--- a/installation_and_upgrade/ibex_install_utils/tasks/client_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/client_tasks.py
@@ -1,10 +1,10 @@
 import os
 import subprocess
 
-from installation_and_upgrade.ibex_install_utils.run_process import RunProcess
-from installation_and_upgrade.ibex_install_utils.task import task
-from installation_and_upgrade.ibex_install_utils.tasks import BaseTasks
-from installation_and_upgrade.ibex_install_utils.tasks.common_paths import APPS_BASE_DIR, GUI_PATH_E4
+from ibex_install_utils.run_process import RunProcess
+from ibex_install_utils.task import task
+from ibex_install_utils.tasks import BaseTasks
+from ibex_install_utils.tasks.common_paths import APPS_BASE_DIR, GUI_PATH_E4
 
 
 class ClientTasks(BaseTasks):

--- a/installation_and_upgrade/ibex_install_utils/tasks/mysql_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/mysql_tasks.py
@@ -4,13 +4,13 @@ import subprocess
 import zipfile
 from time import sleep
 
-from installation_and_upgrade.ibex_install_utils.admin_runner import AdminCommandBuilder
-from installation_and_upgrade.ibex_install_utils.exceptions import ErrorInRun
-from installation_and_upgrade.ibex_install_utils.run_process import RunProcess
-from installation_and_upgrade.ibex_install_utils.task import task
-from installation_and_upgrade.ibex_install_utils.tasks import BaseTasks
-from installation_and_upgrade.ibex_install_utils.tasks.common_paths import APPS_BASE_DIR, INST_SHARE_AREA, VAR_DIR, STAGE_DELETED, EPICS_PATH
-from installation_and_upgrade.ibex_install_utils.user_prompt import UserPrompt
+from ibex_install_utils.admin_runner import AdminCommandBuilder
+from ibex_install_utils.exceptions import ErrorInRun
+from ibex_install_utils.run_process import RunProcess
+from ibex_install_utils.task import task
+from ibex_install_utils.tasks import BaseTasks
+from ibex_install_utils.tasks.common_paths import APPS_BASE_DIR, INST_SHARE_AREA, VAR_DIR, STAGE_DELETED, EPICS_PATH
+from ibex_install_utils.user_prompt import UserPrompt
 
 try:
     from subprocess import DETACHED_PROCESS

--- a/installation_and_upgrade/ibex_install_utils/tasks/python_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/python_tasks.py
@@ -1,9 +1,9 @@
 import os
 
-from installation_and_upgrade.ibex_install_utils.run_process import RunProcess
-from installation_and_upgrade.ibex_install_utils.task import task
-from installation_and_upgrade.ibex_install_utils.tasks import BaseTasks
-from installation_and_upgrade.ibex_install_utils.tasks.common_paths import APPS_BASE_DIR
+from ibex_install_utils.run_process import RunProcess
+from ibex_install_utils.task import task
+from ibex_install_utils.tasks import BaseTasks
+from ibex_install_utils.tasks.common_paths import APPS_BASE_DIR
 
 
 class PythonTasks(BaseTasks):

--- a/installation_and_upgrade/ibex_install_utils/tasks/server_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/server_tasks.py
@@ -5,7 +5,7 @@ import lxml.etree
 import os
 import subprocess
 
-from installation_and_upgrade.ibex_install_utils.user_prompt import UserPrompt
+from ibex_install_utils.user_prompt import UserPrompt
 
 try:
     from contextlib import contextmanager
@@ -14,15 +14,15 @@ except ImportError:
 
 import git
 
-from installation_and_upgrade.ibex_install_utils.exceptions import ErrorInTask, ErrorInRun
-from installation_and_upgrade.ibex_install_utils.motor_params import get_params_and_save_to_file
-from installation_and_upgrade.ibex_install_utils.run_process import RunProcess
-from installation_and_upgrade.ibex_install_utils.task import task
-from installation_and_upgrade.ibex_install_utils.tasks import BaseTasks
-from installation_and_upgrade.ibex_install_utils.tasks.common_paths import APPS_BASE_DIR, INSTRUMENT_BASE_DIR, VAR_DIR, EPICS_PATH, \
+from ibex_install_utils.exceptions import ErrorInTask, ErrorInRun
+from ibex_install_utils.motor_params import get_params_and_save_to_file
+from ibex_install_utils.run_process import RunProcess
+from ibex_install_utils.task import task
+from ibex_install_utils.tasks import BaseTasks
+from ibex_install_utils.tasks.common_paths import APPS_BASE_DIR, INSTRUMENT_BASE_DIR, VAR_DIR, EPICS_PATH, \
     SETTINGS_CONFIG_PATH, SETTINGS_CONFIG_FOLDER, INST_SHARE_AREA
-from installation_and_upgrade.ibex_install_utils.file_utils import LABVIEW_DAE_DIR, get_latest_directory_path
-from installation_and_upgrade.ibex_install_utils.admin_runner import AdminCommandBuilder
+from ibex_install_utils.file_utils import LABVIEW_DAE_DIR, get_latest_directory_path
+from ibex_install_utils.admin_runner import AdminCommandBuilder
 
 CONFIG_UPGRADE_SCRIPT_DIR = os.path.join(EPICS_PATH, "misc", "upgrade", "master")
 
@@ -184,7 +184,7 @@ class ServerTasks(BaseTasks):
         else:
             exit_code = subprocess.call("git clone http://control-svcs.isis.cclrc.ac.uk/gitroot/instconfigs/common.git "
                                         "C:\Instrument\Settings\config\common")
-            if exit_code is not 0:
+            if exit_code != 0:
                 raise ErrorInRun("Failed to set up common calibration directory.")
 
     @task("Updating calibrations repository")

--- a/installation_and_upgrade/ibex_install_utils/tasks/system_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/system_tasks.py
@@ -1,16 +1,15 @@
 import filecmp
 import os
-import shutil
 
 import psutil
 
-from installation_and_upgrade.ibex_install_utils.admin_runner import AdminCommandBuilder
-from installation_and_upgrade.ibex_install_utils.exceptions import UserStop
-from installation_and_upgrade.ibex_install_utils.kafka_utils import add_required_topics
-from installation_and_upgrade.ibex_install_utils.run_process import RunProcess
-from installation_and_upgrade.ibex_install_utils.task import task
-from installation_and_upgrade.ibex_install_utils.tasks import BaseTasks
-from installation_and_upgrade.ibex_install_utils.tasks.common_paths import APPS_BASE_DIR, EPICS_PATH
+from ibex_install_utils.admin_runner import AdminCommandBuilder
+from ibex_install_utils.exceptions import UserStop
+from ibex_install_utils.kafka_utils import add_required_topics
+from ibex_install_utils.run_process import RunProcess
+from ibex_install_utils.task import task
+from ibex_install_utils.tasks import BaseTasks
+from ibex_install_utils.tasks.common_paths import APPS_BASE_DIR, EPICS_PATH
 
 GIGABYTE = 1024 ** 3
 

--- a/installation_and_upgrade/ibex_install_utils/tasks/vhd_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/vhd_tasks.py
@@ -3,11 +3,11 @@ import shutil
 import tempfile
 from time import sleep
 
-from installation_and_upgrade.ibex_install_utils.admin_runner import AdminCommandBuilder
-from installation_and_upgrade.ibex_install_utils.run_process import RunProcess
-from installation_and_upgrade.ibex_install_utils.task import task
-from installation_and_upgrade.ibex_install_utils.tasks import BaseTasks
-from installation_and_upgrade.ibex_install_utils.tasks.common_paths import INSTRUMENT_BASE_DIR, INST_SHARE_AREA, EPICS_PATH, APPS_BASE_DIR, \
+from ibex_install_utils.admin_runner import AdminCommandBuilder
+from ibex_install_utils.run_process import RunProcess
+from ibex_install_utils.task import task
+from ibex_install_utils.tasks import BaseTasks
+from ibex_install_utils.tasks.common_paths import INSTRUMENT_BASE_DIR, INST_SHARE_AREA, EPICS_PATH, APPS_BASE_DIR, \
     SETTINGS_CONFIG_PATH, VAR_DIR
 
 

--- a/installation_and_upgrade/vhd_scheduled_task.py
+++ b/installation_and_upgrade/vhd_scheduled_task.py
@@ -4,9 +4,9 @@ Script to install IBEX to various machines
 import sys
 import traceback
 
-from installation_and_upgrade.ibex_install_utils.install_tasks import UpgradeInstrument
-from installation_and_upgrade.ibex_install_utils.exceptions import UserStop, ErrorInTask
-from installation_and_upgrade.ibex_install_utils.user_prompt import UserPrompt
+from ibex_install_utils.install_tasks import UpgradeInstrument
+from ibex_install_utils.exceptions import UserStop, ErrorInTask
+from ibex_install_utils.user_prompt import UserPrompt
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The system tests are currently failing on this step as the imports are absolute from the root of the repo which is not how the scripts are run. 

