### PR TITLE
Fix VHD build: round 2

### DIFF
--- a/installation_and_upgrade/ibex_install_utils/tasks/server_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/server_tasks.py
@@ -130,7 +130,9 @@ class ServerTasks(BaseTasks):
         if not os.path.exists(os.path.join(inst_scripts_path, f"init_{inst_name.lower()}.py")):
             try:
                 generic_inst_file = os.path.join(inst_scripts_path, "init_inst_name.py")
-                specific_inst_file = os.path.join(inst_scripts_path, f"init_{inst_name.lower()}.py")
+
+                # Specific inst file postfix is inst_name.lower()[3:] as we need to trim off NDE/NDX/NDH/NDW
+                specific_inst_file = os.path.join(inst_scripts_path, f"init_{inst_name.lower()[3:]}.py")
                 if not os.path.exists(specific_inst_file):
                     if not os.path.exists(generic_inst_file):
                         raise IOError("Generic inst file at {} did not exist - cannot proceed".format(generic_inst_file))

--- a/installation_and_upgrade/ibex_install_utils/tasks/vhd_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/vhd_tasks.py
@@ -144,7 +144,7 @@ class VHDTasks(BaseTasks):
             # Remove directory junction
             admin_commands.add_command(
                 "cmd",
-                r'/c f"rmdir {mount_point}"'.format(mount_point=vhd.mount_point),
+                r'/c "rmdir {mount_point}"'.format(mount_point=vhd.mount_point),
                 expected_return_val=None,
             )
 

--- a/installation_and_upgrade/vhd_scheduled_task.py
+++ b/installation_and_upgrade/vhd_scheduled_task.py
@@ -12,7 +12,7 @@ from ibex_install_utils.user_prompt import UserPrompt
 if __name__ == "__main__":
     try:
         prompt = UserPrompt(automatic=True, confirm_steps=False)
-        upgrade_instrument = UpgradeInstrument(prompt, None, None, None, None)
+        upgrade_instrument = UpgradeInstrument(prompt, None, None, None, None, None)
         upgrade_instrument.dismount_vhds()
         upgrade_instrument.mount_vhds()
     except UserStop:


### PR DESCRIPTION
- Fix stray `f` which somehow got added in dismount commands
- Fix looking for wrong python init file (on `NDHSPARE70` should be `init_spare70.py`)
- Fix number of arguments being passed to upgrade script.