### PR TITLE
Ticket5906 temp admin file

### DIFF
--- a/installation_and_upgrade/ibex_install_utils/admin_runner.py
+++ b/installation_and_upgrade/ibex_install_utils/admin_runner.py
@@ -69,5 +69,3 @@ def temp_bat_file(contents):
         yield f.name
     finally:
         os.remove(f.name)
-
-

--- a/installation_and_upgrade/ibex_install_utils/admin_runner.py
+++ b/installation_and_upgrade/ibex_install_utils/admin_runner.py
@@ -51,7 +51,7 @@ class AdminCommandBuilder:
                 bat_file += f"if %errorlevel% neq {expected_return_val} exit /B 1\r\n"
 
         bat_file += "exit /B 0\r\n"
-        file = tempfile.TemporaryFile()
+        file = tempfile.NamedTemporaryFile(suffix=".bat")
 
         try:
             file.write(bat_file.encode("utf-8"))
@@ -63,3 +63,8 @@ class AdminCommandBuilder:
         finally:
             # Closing the file will delete it
             file.close()
+
+
+if __name__ == '__main__':
+    cmd = AdminCommandBuilder()
+    cmd.run_all()

--- a/installation_and_upgrade/ibex_install_utils/admin_runner.py
+++ b/installation_and_upgrade/ibex_install_utils/admin_runner.py
@@ -3,6 +3,7 @@ import tempfile
 from time import sleep
 import os
 
+
 class AdminRunner:
     @staticmethod
     def run_command(command, parameters, expected_return_val=0):

--- a/installation_and_upgrade/ibex_install_utils/admin_runner.py
+++ b/installation_and_upgrade/ibex_install_utils/admin_runner.py
@@ -1,4 +1,3 @@
-import os
 import tempfile
 from time import sleep
 

--- a/installation_and_upgrade/ibex_install_utils/admin_runner.py
+++ b/installation_and_upgrade/ibex_install_utils/admin_runner.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 from time import sleep
 
 
@@ -51,14 +52,15 @@ class AdminCommandBuilder:
                 bat_file += f"if %errorlevel% neq {expected_return_val} exit /B 1\r\n"
 
         bat_file += "exit /B 0\r\n"
+        file = tempfile.TemporaryFile()
 
-        filename = os.path.join("C:\\", "Instrument", "temp.bat")
-        with open(filename, "w") as f:
-            f.write(bat_file)
-
-        print(f"Executing bat script as admin. Saved as {filename}. Check for an admin prompt. Contents:\r\n{bat_file}")
-
-        sleep(1)  # Wait for file handle to be closed etc
-        AdminRunner.run_command("cmd", f"/c {filename}")
-        sleep(1)  # Wait for commands to fully die etc
-        os.remove(filename)
+        try:
+            file.write(bat_file.encode("utf-8"))
+            file.flush()
+            print(f"Executing bat script as admin. Saved as {file.name}. Check for an admin prompt. Contents:\r\n{bat_file}")
+            sleep(1)  # Wait for file handle to be closed etc
+            AdminRunner.run_command("cmd", f"/c {file.name}")
+            sleep(1)  # Wait for commands to fully die etc
+        finally:
+            # Closing the file will delete it
+            file.close()

--- a/installation_and_upgrade/ibex_install_utils/admin_runner.py
+++ b/installation_and_upgrade/ibex_install_utils/admin_runner.py
@@ -71,6 +71,3 @@ def temp_bat_file(contents):
         os.remove(f.name)
 
 
-if __name__ == '__main__':
-    cmd = AdminCommandBuilder()
-    cmd.run_all()


### PR DESCRIPTION
Uses a TemporaryFile instead of a hardcoded bat file, i added a context manager here so we can use it elsewhere if needed. 

See ISISComputingGroup/IBEX#5906


### To test: 
Add
```python
if __name__ == '__main__':
    cmd = AdminCommandBuilder()
    cmd.run_all()
```
to the end of the script
and a 60 second sleep in the `with temp_bat_file` statement

- check the file exists before it is executed (usually in `C:\Users\username\AppData\Local\Temp`, it will be a randomly-named bat script
- check it is removed thereafter