### PR TITLE
Make prompt clearer

### DIFF
--- a/installation_and_upgrade/ibex_install_utils/tasks/server_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/server_tasks.py
@@ -383,7 +383,7 @@ class ServerTasks(BaseTasks):
             else:
                 print(f"DAE type {dae_type} not recognised, not installing ICP")
                 return
-            self.prompt.confirm_step(f"Upgrade DAE{dae_type} type ICP found in Labview Modules")
+            self.prompt.confirm_step(f"Upgrade ICP found in Labview Modules? (Detected type: DAE{dae_type})")
             icp_path = get_latest_directory_path(os.path.join(INST_SHARE_AREA, "kits$", "CompGroup", "ICP", "ISISICP",
                                                               f"DAE{dae_type}"), "")
 


### PR DESCRIPTION
Make clear in prompt that DAE type is automatically detected, not selected from user input