### PR TITLE
Ticket6575 check stale builds

### DIFF
--- a/build_tools/JenkinsfileCheckRecentBuilds
+++ b/build_tools/JenkinsfileCheckRecentBuilds
@@ -23,8 +23,7 @@ pipeline {
         stage("Check Instrument Scripts") {
             steps {
                 bat """
-                    dir
-                    call check_builds_are_recent.bat
+                    call builds_tools/check_builds_are_recent.bat
                 """
             }
         }

--- a/build_tools/JenkinsfileCheckRecentBuilds
+++ b/build_tools/JenkinsfileCheckRecentBuilds
@@ -1,0 +1,32 @@
+#!groovy
+
+pipeline {
+
+    agent {  
+        label {
+            label "scriptchecker"
+        }
+    }
+
+    triggers {
+        cron('H 1 * * *')
+    }
+
+    stages {  
+
+        stage("Checkout") {
+            steps {
+                checkout scm
+            }
+        }
+
+        stage("Check Instrument Scripts") {
+            steps {
+                bat """
+                    dir
+                    call check_builds_are_recent.bat
+                """
+            }
+        }
+    }
+}

--- a/build_tools/JenkinsfileCheckRecentBuilds
+++ b/build_tools/JenkinsfileCheckRecentBuilds
@@ -23,7 +23,7 @@ pipeline {
         stage("Check Instrument Scripts") {
             steps {
                 bat """
-                    call builds_tools/check_builds_are_recent.bat
+                    call build_tools/check_builds_are_recent.bat
                 """
             }
         }

--- a/build_tools/check_builds_are_recent.bat
+++ b/build_tools/check_builds_are_recent.bat
@@ -1,0 +1,3 @@
+call "%~dp0..\installation_and_upgrade\define_latest_genie_python.bat" 3
+set PYTHONUNBUFFERED=TRUE
+call "%LATEST_PYTHON%" "%~dp0check_builds_are_recent.py"

--- a/build_tools/check_builds_are_recent.py
+++ b/build_tools/check_builds_are_recent.py
@@ -1,0 +1,51 @@
+import os
+from typing import Union
+from datetime import datetime
+
+kits_root = r"\\isis\inst$\kits$\CompGroup\ICP"
+build_dirs = ["Client_E4"]
+
+def get_latest_build(dir) -> Union[None, str]:
+    latest_build = None
+    with open(os.path.join(dir, "LATEST_BUILD.txt")) as latest_build_file:
+        latest_build = latest_build_file.readline().strip()
+    latest_build_dir = os.path.join(dir, f"BUILD{latest_build}") if latest_build is not None else None
+    return latest_build_dir
+
+def get_last_modified_datetime(dir):
+    time_in_seconds_of_last_modification = os.path.getmtime(dir)
+    datetime_of_last_modification = datetime.fromtimestamp(time_in_seconds_of_last_modification)
+    return datetime_of_last_modification
+
+def get_formatted_last_modified_datetime(dir):
+    last_modified_date = get_last_modified_datetime(dir)
+    return last_modified_date.strftime("%d/%m/%Y, %H:%M:%S")
+
+def modified_in_last_x_days(dir, x_days):
+    datetime_of_last_modification = get_last_modified_datetime(dir)
+    datetime_now = datetime.now()
+    timedelta_since_last_modification = datetime_now - datetime_of_last_modification
+    return timedelta_since_last_modification.days < x_days
+
+def confirm_success_or_failure(latest_build):
+    x_days = 5
+    last_modified_datetime = get_formatted_last_modified_datetime(latest_build)
+    if modified_in_last_x_days(latest_build, x_days):
+        print(f"SUCCESS: {latest_build} has been modified in the last {x_days} days. Last modified: {last_modified_datetime}")
+    else:
+        print(f"WARNING: {latest_build} modified longer than {x_days} ago. Last modified: {last_modified_datetime}")
+
+def check_build_dir(build_dir):
+    latest_build = get_latest_build(build_dir)
+    if latest_build is None:
+            print(f"WARNING: Could not get latest build dir from {build_dir}")
+    else:
+        confirm_success_or_failure(latest_build)
+
+def check_build_dirs(build_dirs):
+    for build_dir in build_dirs:
+        build_dir_full_path = os.path.join(kits_root, build_dir)
+        check_build_dir(build_dir_full_path)
+
+if __name__ == "__main__":
+    check_build_dirs(build_dirs)


### PR DESCRIPTION
I've added a tool in https://github.com/ISISComputingGroup/ibex_utils/pull/119 that runs on Jenkins to check for kits$ for if the client, epics and genie python most recent builds are more than 5 days old. See https://epics-jenkins.isis.rl.ac.uk/view/WallDisplay/job/Stale%20Builds%20Checker/ for it running. When merged we need to change the branch of this checker Jenkins job back to master.