### PR TITLE
Ticket 7227 - stop multiple python installs

### DIFF
--- a/installation_and_upgrade/IBEX_upgrade.py
+++ b/installation_and_upgrade/IBEX_upgrade.py
@@ -40,7 +40,6 @@ if __name__ == "__main__":
     parser.add_argument("--server_build_prefix", default="EPICS", help="Prefix for build directory name")
     parser.add_argument("--server_dir", default=None, help="Directory from which IBEX server should be installed")
     parser.add_argument("--client_dir", default=None, help="Directory from which IBEX client should be installed")
-    parser.add_argument("--client_e4_dir", default=None, help="Directory from which IBEX E4 client should be installed")
     parser.add_argument("--genie_python3_dir", default=None,
                         help="Directory from which genie_python_3 should be installed")
     parser.add_argument("--confirm_step", default=False, action="store_true",
@@ -56,7 +55,6 @@ if __name__ == "__main__":
                         .format(", \n".join(deployment_types)))
 
     args = parser.parse_args()
-    client_e4_dir = args.client_e4_dir
     current_client_version = None
     if args.release_dir is not None:
         current_release_dir = os.path.join(args.release_dir, _get_latest_release_path(args.release_dir))
@@ -65,7 +63,6 @@ if __name__ == "__main__":
             current_release_dir += f"-{args.release_suffix}"
         server_dir = os.path.join(current_release_dir, "EPICS")
         client_dir = os.path.join(current_release_dir, "Client")
-        client_e4_dir = client_dir
         genie_python3_dir = os.path.join(current_release_dir, "genie_python_3")
 
     elif args.kits_icp_dir is not None:
@@ -80,29 +77,24 @@ if __name__ == "__main__":
             client_build_dir = os.path.join(args.kits_icp_dir, "Client")
             client_dir = get_latest_directory_path(client_build_dir, "BUILD")
 
-            client_e4_build_dir = os.path.join(args.kits_icp_dir, "Client_E4")
-            client_e4_dir = get_latest_directory_path(client_e4_build_dir, "BUILD")
-
             genie_python3_build_dir = os.path.join(args.kits_icp_dir, "genie_python_3")
             genie_python3_dir = get_latest_directory_path(genie_python3_build_dir, "BUILD-")
         except IOError as e:
             print(e)
             sys.exit(3)
 
-    elif args.server_dir is not None and args.client_dir is not None and args.genie_python3_dir is not None and \
-            args.client_e4_dir is not None:
+    elif args.server_dir is not None and args.client_dir is not None and args.genie_python3_dir is not None:
         server_dir = args.server_dir
         client_dir = args.client_dir
-        client_e4_dir = args.client_e4_dir
         genie_python3_dir = args.genie_python3_dir
     else:
         print("You must specify either the release directory or kits_icp_dir or "
-              "ALL of the server, client, client e4 and genie python 3 directories.")
+              "ALL of the server, client and genie python 3 directories.")
         sys.exit(2)
 
     try:
         prompt = UserPrompt(args.quiet, args.confirm_step)
-        upgrade_instrument = UpgradeInstrument(prompt, server_dir, client_dir, client_e4_dir, genie_python3_dir,
+        upgrade_instrument = UpgradeInstrument(prompt, server_dir, client_dir, genie_python3_dir,
                                                current_client_version)
         upgrade_function = UPGRADE_TYPES[args.deployment_type][0]
         upgrade_function(upgrade_instrument)

--- a/installation_and_upgrade/ibex_install_utils/install_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/install_tasks.py
@@ -241,7 +241,7 @@ class UpgradeInstrument:
             self._server_tasks.install_ibex_server()
             self._python_tasks.install_genie_python3()
             self._mysql_tasks.install_mysql_for_vhd()
-            self._client_tasks.install_ibex_client_with_()
+            self._client_tasks.install_ibex_client()
             self._server_tasks.setup_config_repository()
             self._server_tasks.upgrade_instrument_configuration()
             self._server_tasks.setup_calibrations_repository()

--- a/installation_and_upgrade/ibex_install_utils/install_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/install_tasks.py
@@ -18,7 +18,7 @@ class UpgradeInstrument:
     """
     Class to upgrade the instrument installation to the given version of IBEX.
     """
-    def __init__(self, user_prompt, server_source_dir, client_source_dir, client_e4_source_dir, genie_python3_dir,
+    def __init__(self, user_prompt, server_source_dir, client_source_dir, genie_python3_dir,
                  ibex_version, file_utils=FileUtils()):
         """
         Initializer.
@@ -26,31 +26,30 @@ class UpgradeInstrument:
             user_prompt: a object to allow prompting of the user
             server_source_dir: directory to install ibex server from
             client_source_dir: directory to install ibex client from
-            client_e4_source_dir: directory to install ibex E4 client from
             genie_python3_dir: directory to install genie_python 3 from
             ibex_version: version number of ibex that we are upgrading to
             file_utils : collection of file utilities
         """
         self._client_tasks = ClientTasks(
-            user_prompt, server_source_dir, client_source_dir, client_e4_source_dir, genie_python3_dir, ibex_version, file_utils)
+            user_prompt, server_source_dir, client_source_dir, genie_python3_dir, ibex_version, file_utils)
 
         self._mysql_tasks = MysqlTasks(
-            user_prompt, server_source_dir, client_source_dir, client_e4_source_dir, genie_python3_dir, ibex_version, file_utils)
+            user_prompt, server_source_dir, client_source_dir, genie_python3_dir, ibex_version, file_utils)
 
         self._python_tasks = PythonTasks(
-            user_prompt, server_source_dir, client_source_dir, client_e4_source_dir, genie_python3_dir, ibex_version, file_utils)
+            user_prompt, server_source_dir, client_source_dir, genie_python3_dir, ibex_version, file_utils)
 
         self._server_tasks = ServerTasks(
-            user_prompt, server_source_dir, client_source_dir, client_e4_source_dir, genie_python3_dir, ibex_version, file_utils)
+            user_prompt, server_source_dir, client_source_dir, genie_python3_dir, ibex_version, file_utils)
 
         self._system_tasks = SystemTasks(
-            user_prompt, server_source_dir, client_source_dir, client_e4_source_dir, genie_python3_dir, ibex_version, file_utils)
+            user_prompt, server_source_dir, client_source_dir, genie_python3_dir, ibex_version, file_utils)
 
         self._vhd_tasks = VHDTasks(
-            user_prompt, server_source_dir, client_source_dir, client_e4_source_dir, genie_python3_dir, ibex_version, file_utils)
+            user_prompt, server_source_dir, client_source_dir, genie_python3_dir, ibex_version, file_utils)
 
         self._backup_tasks = BackupTasks(
-            user_prompt, server_source_dir, client_source_dir, client_e4_source_dir, genie_python3_dir, ibex_version, file_utils)
+            user_prompt, server_source_dir, client_source_dir, genie_python3_dir, ibex_version, file_utils)
 
     @staticmethod
     def icp_in_labview_modules():
@@ -94,7 +93,7 @@ class UpgradeInstrument:
         self._server_tasks.install_ibex_server(use_old_galil)
         self._server_tasks.update_icp(self.icp_in_labview_modules(), register_icp=False)
         self._python_tasks.install_genie_python3()
-        self._client_tasks.install_e4_ibex_client()
+        self._client_tasks.install_ibex_client()
         self._server_tasks.upgrade_instrument_configuration()
         self._server_tasks.install_shared_scripts_repository()
 
@@ -242,7 +241,7 @@ class UpgradeInstrument:
             self._server_tasks.install_ibex_server()
             self._python_tasks.install_genie_python3()
             self._mysql_tasks.install_mysql_for_vhd()
-            self._client_tasks.install_e4_ibex_client()
+            self._client_tasks.install_ibex_client_with_()
             self._server_tasks.setup_config_repository()
             self._server_tasks.upgrade_instrument_configuration()
             self._server_tasks.setup_calibrations_repository()
@@ -278,6 +277,7 @@ class UpgradeInstrument:
         """
         #self._server_tasks.update_icp(self.icp_in_labview_modules())
         self._mysql_tasks.configure_mysql_for_vhd_post_install()
+
 
 # All possible upgrade tasks
 UPGRADE_TYPES = {

--- a/installation_and_upgrade/ibex_install_utils/tasks/__init__.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/__init__.py
@@ -8,7 +8,7 @@ from ibex_install_utils.tasks.common_paths import BACKUP_DIR, BACKUP_DATA_DIR
 
 
 class BaseTasks:
-    def __init__(self, user_prompt, server_source_dir, client_source_dir, client_e4_source_dir, genie_python3_dir,
+    def __init__(self, user_prompt, server_source_dir, client_source_dir, genie_python3_dir,
                  ibex_version, file_utils=FileUtils()):
         """
         Initializer.
@@ -16,7 +16,6 @@ class BaseTasks:
             user_prompt (ibex_install_utils.user_prompt.UserPrompt): a object to allow prompting of the user
             server_source_dir: directory to install ibex server from
             client_source_dir: directory to install ibex client from
-            client_e4_source_dir: directory to install ibex E4 client from
             genie_python3_dir: directory to install genie python from
             file_utils : collection of file utilities
             ibex_version : the version of ibex being installed
@@ -24,7 +23,6 @@ class BaseTasks:
         self.prompt = user_prompt  # This is needed to allow @tasks to work
         self._server_source_dir = server_source_dir
         self._client_source_dir = client_source_dir
-        self._client_e4_source_dir = client_e4_source_dir
         self._genie_python_3_source_dir = genie_python3_dir
         self._file_utils = file_utils
         self._ibex_version = ibex_version
@@ -51,7 +49,6 @@ class BaseTasks:
     @staticmethod
     def _today_date_for_filenames():
         return date.today().strftime("%Y_%m_%d")
-
 
     @staticmethod
     def _get_backup_dir():

--- a/installation_and_upgrade/ibex_install_utils/tasks/backup_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/backup_tasks.py
@@ -5,9 +5,9 @@ import shutil
 from ibex_install_utils.task import task
 from ibex_install_utils.tasks import BaseTasks
 from ibex_install_utils.tasks.common_paths import INSTRUMENT_BASE_DIR, BACKUP_DATA_DIR, BACKUP_DIR, EPICS_PATH, \
-    PYTHON_PATH, PYTHON_3_PATH, EPICS_UTILS_PATH, GUI_PATH, GUI_PATH_E4
+    PYTHON_PATH, PYTHON_3_PATH, EPICS_UTILS_PATH, GUI_PATH
 
-ALL_INSTALL_DIRECTORIES = (EPICS_PATH, PYTHON_PATH, PYTHON_3_PATH, GUI_PATH, GUI_PATH_E4, EPICS_UTILS_PATH)
+ALL_INSTALL_DIRECTORIES = (EPICS_PATH, PYTHON_PATH, PYTHON_3_PATH, GUI_PATH, EPICS_UTILS_PATH)
 
 
 class BackupTasks(BaseTasks):

--- a/installation_and_upgrade/ibex_install_utils/tasks/client_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/client_tasks.py
@@ -4,30 +4,18 @@ import subprocess
 from ibex_install_utils.run_process import RunProcess
 from ibex_install_utils.task import task
 from ibex_install_utils.tasks import BaseTasks
-from ibex_install_utils.tasks.common_paths import APPS_BASE_DIR, GUI_PATH_E4
+from ibex_install_utils.tasks.common_paths import APPS_BASE_DIR, GUI_PATH
 
 
 class ClientTasks(BaseTasks):
 
-    @task("Installing IBEX Client")
+    @task("Installing IBEX Client with builtin python")
     def install_ibex_client(self):
         """
-        Install the ibex client (which also installs genie python).
+        Install the ibex client with builtin python.
 
         """
         self._install_set_version_of_ibex_client(self._client_source_dir)
-
-    @task("Installing IBEX Client")
-    def install_e4_ibex_client(self):
-        """
-        Install the ibex client E4 version (which also installs genie python).
-
-        """
-        source_dir = self._client_e4_source_dir
-        if source_dir is None:
-            self.prompt.prompt_and_raise_if_not_yes("The E4 client path has not been set; continue with installation?")
-        else:
-            self._install_set_version_of_ibex_client(source_dir)
 
     def _install_set_version_of_ibex_client(self, source_dir):
         """
@@ -37,7 +25,7 @@ class ClientTasks(BaseTasks):
         """
         self._file_utils.mkdir_recursive(APPS_BASE_DIR)
 
-        RunProcess(source_dir, "install_client.bat", prog_args=["NOINT"]).run()
+        RunProcess(source_dir, "install_gui_with_builtin_python.bat", prog_args=["NOINT"]).run()
 
     @task("Starting IBEX gui")
     def start_ibex_gui(self):
@@ -45,7 +33,7 @@ class ClientTasks(BaseTasks):
         Start the IBEX GUI
         :return:
         """
-        subprocess.Popen([os.path.join(GUI_PATH_E4, "ibex-client.exe")], cwd=GUI_PATH_E4)
+        subprocess.Popen([os.path.join(GUI_PATH, "ibex-client.exe")], cwd=GUI_PATH)
 
     @task("Client release tests")
     def perform_client_tests(self):

--- a/installation_and_upgrade/ibex_install_utils/tasks/common_paths.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/common_paths.py
@@ -20,6 +20,4 @@ STAGE_DELETED = os.path.join(INST_SHARE_AREA, "backups$", "stage-deleted")
 PYTHON_PATH = os.path.join(APPS_BASE_DIR, "Python")
 PYTHON_3_PATH = os.path.join(APPS_BASE_DIR, "Python3")
 
-
 GUI_PATH = os.path.join(APPS_BASE_DIR, "Client")
-GUI_PATH_E4 = os.path.join(APPS_BASE_DIR, "Client_E4")

--- a/installation_and_upgrade/vhd_post_install.bat
+++ b/installation_and_upgrade/vhd_post_install.bat
@@ -10,5 +10,5 @@ IF EXIST "C:\Instrument\Apps\EPICS\stop_ibex_server.bat" (
   start /wait cmd /c "C:\Instrument\Apps\EPICS\stop_ibex_server.bat"
 )
 
-call "C:\Instrument\Apps\Python3\python.exe" -u "%~dp0IBEX_upgrade.py" --client_dir="%TEMP%" --server_dir="%TEMP%" --client_e4_dir="%TEMP%" --genie_python3_dir="%TEMP%" run_vhd_post_install --quiet
+call "C:\Instrument\Apps\Python3\python.exe" -u "%~dp0IBEX_upgrade.py" --client_dir="%TEMP%" --server_dir="%TEMP%" --genie_python3_dir="%TEMP%" run_vhd_post_install --quiet
 IF %ERRORLEVEL% NEQ 0 EXIT /b %errorlevel%


### PR DESCRIPTION
- Changed the ibex client install to reference the new `install_client_with_builtin_python.bat` to remove instances of double installs for external genie python 3 (i.e., Instrument/Apps/Python3)
- Simplified the ibex client install logic by removing references to Client_E4