### PR TITLE
Updated IOC copier to allow creation of IOC 2

### DIFF
--- a/ioc_copier/ioc_copier.py
+++ b/ioc_copier/ioc_copier.py
@@ -36,7 +36,7 @@ def rename_files(root_folder, rename, ioc):
                                                            f"{ioc}_{padded_current_copy}")))
 
 
-def replace_text(text_lines, ioc, skip=[]):
+def replace_text(text_lines, ioc, skip=None):
     """
     Function to handle replacing of text within files.
     Parameters:
@@ -46,6 +46,8 @@ def replace_text(text_lines, ioc, skip=[]):
     return:
         The new text to be placed in the file.
     """
+    if skip is None:
+        skip = []
     return [replace_line(ioc, line) if index not in skip else line for index, line in enumerate(text_lines)]
 
 


### PR DESCRIPTION
Made changes to ioc copier script so that it can be used on IOC-01 to create IOC-02 and up. Due to there being more edge cases on doing so, added restrictions so that IOCs that are likely to cause problems (No st-common.cmd or use of sequencer) the script will fail. 
And use of asub records within the ioc directory itself will warn the user that they may need to check the C++.

https://github.com/ISISComputingGroup/IBEX/issues/7353
