### PR TITLE
Ticket7441

### DIFF
--- a/installation_and_upgrade/ibex_install_utils/tasks/server_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/server_tasks.py
@@ -441,7 +441,8 @@ class ServerTasks(BaseTasks):
             if answer == "Y":
                 return True
             else:
-                return False
+                print("Old Galil driver is default - only change to new driver if you explicitly know this is needed!")
+                return not self.prompt.confirm_step("Use new Galil driver")
 
     def _swap_galil_driver(self, use_old):
         """


### PR DESCRIPTION
https://github.com/ISISComputingGroup/IBEX/issues/7441

Confirmed that GALIL driver selection works as expected and added a secondary prompt if a choice between drivers is given by the deploy script.

The script prompts for a choice if either `GALIL-OLD` or `GALIL-NEW` directory is missing.