### PR TITLE
Add parameter for 32bit deploys and clarify system task name

### DIFF
--- a/installation_and_upgrade/ibex_install_utils/tasks/system_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/system_tasks.py
@@ -33,12 +33,12 @@ class SystemTasks(BaseTasks):
     """
     Tasks relating to the system e.g. installed software other than core IBEX components, windows, firewalls, etc.
     """
-    @task("Record running vis or any relevant looking programs")
+    @task("Record running LabVIEW VIs or any relevant looking other programs")
     def record_running_vis(self):
         """
         Get user to record running vis
         """
-        self.prompt.prompt_and_raise_if_not_yes("Write down any VIs/relevant looking programs which are running for use later?")
+        self.prompt.prompt_and_raise_if_not_yes("Write down any LabVIEW VIs/relevant looking programs which are running for use later?")
 
     @task("Upgrading Notepad++. Please follow system dialogs")
     def upgrade_notepad_pp(self):

--- a/installation_and_upgrade/ibex_install_utils/tasks/system_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/system_tasks.py
@@ -33,12 +33,12 @@ class SystemTasks(BaseTasks):
     """
     Tasks relating to the system e.g. installed software other than core IBEX components, windows, firewalls, etc.
     """
-    @task("Record running vis")
+    @task("Record running vis or any relevant looking programs")
     def record_running_vis(self):
         """
         Get user to record running vis
         """
-        self.prompt.prompt_and_raise_if_not_yes("Write down any VIs which are running for use later?")
+        self.prompt.prompt_and_raise_if_not_yes("Write down any VIs/relevant looking programs which are running for use later?")
 
     @task("Upgrading Notepad++. Please follow system dialogs")
     def upgrade_notepad_pp(self):

--- a/installation_and_upgrade/instrument_deploy.bat
+++ b/installation_and_upgrade/instrument_deploy.bat
@@ -5,7 +5,8 @@ call "%~dp0check_for_admin_console.bat"
 IF %errorlevel% neq 0 EXIT /b %errorlevel%
 
 set "SOURCE=\\isis.cclrc.ac.uk\inst$\Kits$\CompGroup\ICP\Releases"
-rem set "RELEASE-SUFFIX="
+set SERVER_ARCH=x64
+if not "%1" == "" set SERVER_ARCH=%1
 
 git --version
 
@@ -25,7 +26,7 @@ IF EXIST "C:\Instrument\Apps\EPICS" (
   set "PYTHONDIR=!LATEST_PYTHON_DIR!"
   set "PYTHONHOME=!LATEST_PYTHON_DIR!"
   set "PYTHONPATH=!LATEST_PYTHON_DIR!"
-  call "!LATEST_PYTHON!" "%~dp0IBEX_upgrade.py" --release_dir "%SOURCE%" --release_suffix "%SUFFIX%" --confirm_step instrument_deploy_pre_stop
+  call "!LATEST_PYTHON!" "%~dp0IBEX_upgrade.py" --release_dir "%SOURCE%" --release_suffix "%SUFFIX%" --server_arch %SERVER_ARCH% --confirm_step instrument_deploy_pre_stop
   IF !errorlevel! neq 0 goto ERROR
   start /wait cmd /c "%STOP_IBEX%"
   ENDLOCAL
@@ -40,7 +41,7 @@ set "PYTHONDIR=%LATEST_PYTHON_DIR%"
 set "PYTHONHOME=%LATEST_PYTHON_DIR%"
 set "PYTHONPATH=%LATEST_PYTHON_DIR%"
 
-call "%LATEST_PYTHON%" "%~dp0IBEX_upgrade.py" --release_dir "%SOURCE%" --release_suffix "%SUFFIX%" --confirm_step instrument_deploy_main
+call "%LATEST_PYTHON%" "%~dp0IBEX_upgrade.py" --release_dir "%SOURCE%" --release_suffix "%SUFFIX%" --server_arch %SERVER_ARCH% --confirm_step instrument_deploy_main 
 IF %errorlevel% neq 0 goto ERROR
 ENDLOCAL
 
@@ -53,6 +54,6 @@ set "PYTHONDIR=%LATEST_PYTHON_DIR%"
 set "PYTHONHOME=%LATEST_PYTHON_DIR%"
 set "PYTHONPATH=%LATEST_PYTHON_DIR%"
 
-call "%LATEST_PYTHON%" "%~dp0IBEX_upgrade.py" --release_dir "%SOURCE%" --release_suffix "%SUFFIX%" --confirm_step instrument_deploy_post_start
+call "%LATEST_PYTHON%" "%~dp0IBEX_upgrade.py" --release_dir "%SOURCE%" --release_suffix "%SUFFIX%" --server_arch %SERVER_ARCH% --confirm_step instrument_deploy_post_start
 :ERROR
 EXIT /b %errorlevel%


### PR DESCRIPTION
- Add parameter to `instrument_deploy.bat` to allow for deploying 32-bit builds.
- Clarify system task `"Record running vis"` into something more coherent. 