### PR TITLE
Do not remove top level directory link

### DIFF
--- a/installation_and_upgrade/ibex_install_utils/tasks/backup_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/backup_tasks.py
@@ -72,4 +72,4 @@ class BackupTasks(BaseTasks):
 
         """
         for path in ALL_INSTALL_DIRECTORIES:
-            self._file_utils.remove_tree(path, self.prompt)
+            self._file_utils.remove_tree(path, self.prompt, leave_top_if_link=True)


### PR DESCRIPTION
If top level EPICS is a link, remove contents of directory it is linked to but do not remove the link itself. We use links a lot on build servers, this is to avoid rename issues and links going missing  