### PR TITLE
Ticket7982

### DIFF
--- a/installation_and_upgrade/ibex_install_utils/tasks/server_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/server_tasks.py
@@ -446,12 +446,18 @@ class ServerTasks(BaseTasks):
         """
         Select galil driver to use. Return True if old driver in operation or should be used
         """
-        if self.ioc_dir_exists("GALIL") and self.ioc_dir_exists("GALIL-NEW") and not self.ioc_dir_exists("GALIL-OLD"):
+        # GALIL_OLD/NEW.txt file gets copied to the tmp dir by instrument_deploy.bat
+        tmpdir = tempfile.gettempdir()
+
+        if os.path.exists(os.path.join(tmpdir, "GALIL_OLD.txt")):
+            os.remove(os.path.join(tmpdir, "GALIL_OLD.txt"))
             # we don't need to swap back to new GALIL for the update as install will remove all files anyway
             # we just need to record our current choice
             print("Old galil driver version detected and will automatically be restored after update.")
             return True
-        elif self.ioc_dir_exists("GALIL") and self.ioc_dir_exists("GALIL-OLD") and not self.ioc_dir_exists("GALIL-NEW"):
+        elif  os.path.exists(os.path.join(tmpdir, "GALIL_NEW.txt")):
+            os.remove(os.path.join(tmpdir, "GALIL_NEW.txt"))
+            print("New galil driver version detected and will automatically be restored after update.")
             return False
         else:
             print("Should the old (Y) or new (N) Galil driver be the current default to run?")

--- a/installation_and_upgrade/instrument_deploy.bat
+++ b/installation_and_upgrade/instrument_deploy.bat
@@ -42,6 +42,22 @@ if exist "%GENIECMDLOGDIR%\%GENIECMDLOGFILE%" (
 	robocopy "%GENIECMDLOGDIR%" "%TEMP%" "%GENIECMDLOGFILE%" /R:2 /IS /NFL /NDL /NP /NC /NS /LOG:NUL
 )
 
+REM Copy the "GALIL_OLD.txt" file, if it exists, to the tmp dir to inform the IBEX Server installation step which Galil version to use
+set "GALIL_OLD_FILE=GALIL_OLD.txt"
+set "GALIL_OLD_DIR=C:\Instrument\Apps\EPICS\ioc\master\GALIL-OLD"
+if exist "%GALIL_OLD_DIR%\%GALIL_OLD_FILE%" (
+	@echo Copying Galil old text file before deleting client
+	robocopy "%GALIL_OLD_DIR%" "%TEMP%" "%GALIL_OLD_FILE%" /R:2 /IS /NFL /NDL /NP /NC /NS /LOG:NUL
+)
+
+REM Copy the "GALIL_NEW.txt" file, if it exists, to the tmp dir to inform the IBEX Server installation step which Galil version to use
+set "GALIL_NEW_FILE=GALIL_NEW.txt"
+set "GALIL_NEW_DIR=C:\Instrument\Apps\EPICS\ioc\master\GALIL-NEW"
+if exist "%GALIL_NEW_DIR%\%GALIL_NEW_FILE%" (
+	@echo Copying Galil new text file before deleting client
+	robocopy "%GALIL_NEW_DIR%" "%TEMP%" "%GALIL_NEW_FILE%" /R:2 /IS /NFL /NDL /NP /NC /NS /LOG:NUL
+)
+
 REM Set python as share just for script call
 call "%~dp0define_latest_genie_python.bat"
 IF %errorlevel% neq 0 goto ERROR


### PR DESCRIPTION
### Description of work

Updated Galil version checker to use a copied GALIL_OLD/NEW.txt file that is now copied before it's overwritten by the IBEX server install (within which you decide the Galil version).

**To test I'd advise just adding in `input()` after each of the 3 options in the `server.tasks.py` file so you can cancel the script before it installs IBEX again.**


### Ticket

[*Link to Ticket*](https://github.com/ISISComputingGroup/IBEX/issues/7982)

### Acceptance criteria

- [ ] Upgrade script either prints out what was last used and gives the option of new/old galil driver, or if straightforward just provides a third option to use the same as last time

### Unit tests

*Give an overview of unit tests you have added or modified, if applicable. The aim is provide information to help the reviewer*

### System tests

*Mention any automated tests or manual tests that you have added or modified, if applicable. The aim is provide information to help the reviewer*

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?

### Final Steps

