### PR TITLE
Removed typo in function call for 'motors, blocks & blockserver' task

### DIFF
--- a/installation_and_upgrade/ibex_install_utils/install_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/install_tasks.py
@@ -169,7 +169,7 @@ class UpgradeInstrument:
         self._client_tasks.perform_client_tests()
         self._server_tasks.perform_server_tests()
         self._server_tasks.run_config_checker()
-        self._server_tasks.save_motor_blocks_blockserver_to_file(0)
+        self._server_tasks.save_motor_blocks_blockserver_to_file()
         self._server_tasks.set_alert_url_and_password()
         self._system_tasks.put_autostart_script_in_startup_area()
         self._system_tasks.inform_instrument_scientists()


### PR DESCRIPTION
I've looked at the commit history of when this bug was introduced. It was added when copying and pasting the line that calls the server task from the `run_instrument_deploy_pre_stop()` function to the `run_instrument_deploy_post_start()` function. This was not noticed in testing as testing only ran through the deploy script till just past the point of which the new functions I wrote run for the first time, emphasis on **first time.** Which I believe to be why the typo has gone unnoticed. 