### PR TITLE
Ticket8186_ignore_list_not_passed_to_move_func

### DIFF
--- a/installation_and_upgrade/ibex_install_utils/tasks/backup_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/backup_tasks.py
@@ -44,7 +44,7 @@ class BackupTasks(BaseTasks):
                     self.update_progress_bar(i, len(all_files))
                     i = i + 1
                     
-    def move_file(self, src, dst, copy=False, ignore=None):
+    def backup_files(self, src, dst, copy=False, ignore=None):
         number_of_files = 0
         current_file_index = 0
 
@@ -56,7 +56,7 @@ class BackupTasks(BaseTasks):
             nonlocal current_file_index
 
             if copy:
-                operation = shutil.copy
+                operation = shutil.copy2
             else:
                 operation = shutil.move
 
@@ -99,11 +99,11 @@ class BackupTasks(BaseTasks):
 
             if copy:
                 print(f"Copying {src} to {backup_dir}")
-                self.move_file(src, backup_dir, copy=True, ignore=ignore)
+                self.backup_files(src, backup_dir, copy=True, ignore=ignore)
                 # self.zip_file(src, backup_dir)
             else:
                 print(f"Moving {src} to {backup_dir}")
-                self.move_file(src, backup_dir, ignore=ignore)
+                self.backup_files(src, backup_dir, ignore=ignore)
                 # self.zip_file(src, backup_dir)
                 
         else: # if src can't be found on the machine

--- a/installation_and_upgrade/ibex_install_utils/tasks/backup_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/backup_tasks.py
@@ -44,7 +44,7 @@ class BackupTasks(BaseTasks):
                     self.update_progress_bar(i, len(all_files))
                     i = i + 1
 
-    def move_file(self, src, dst, copy=False):
+    def move_file(self, src, dst, copy=False, ignore=None):
         all_files = []
         for root, dirs, files in os.walk(src):
             for file in files:
@@ -62,9 +62,12 @@ class BackupTasks(BaseTasks):
             try:
                 if not os.path.exists(dest_dir):
                     os.makedirs(dest_dir)
+                # check if the file is in ignore copytree list and if so skip it
                 if os.path.exists(file):
-                    operation(file, os.path.join(dest_dir, os.path.basename(file)))
-                    i += 1
+                    if ignore is not None:
+                        if not ignore(file, os.path.basename(file)):
+                            operation(file, os.path.join(dest_dir, os.path.basename(file)))
+                            i += 1
                 else:
                     print(f"File not found: {file}")
             except Exception as e:
@@ -98,11 +101,11 @@ class BackupTasks(BaseTasks):
 
             if copy:
                 print(f"Copying {src} to {backup_dir}")
-                self.move_file(src, backup_dir, copy=True)
+                self.move_file(src, backup_dir, copy=True, ignore=ignore)
                 # self.zip_file(src, backup_dir)
             else:
                 print(f"Moving {src} to {backup_dir}")
-                self.move_file(src, backup_dir)
+                self.move_file(src, backup_dir, ignore=ignore)
                 # self.zip_file(src, backup_dir)
                 
         else: # if src can't be found on the machine

--- a/installation_and_upgrade/ibex_install_utils/tasks/backup_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/backup_tasks.py
@@ -17,6 +17,9 @@ class BackupTasks(BaseTasks):
     # lowercase names of directories we are not worried about if they do
     # not exist for example Python which has been Python3 for some time
     FAILED_BACKUP_DIRS_TO_IGNORE = [ r'c:\instrument\apps\python' ]
+    number_of_files = 0
+    current_file_index = 0
+    temp_copy_bool = False
 
     def update_progress_bar(self,progress, total, width=20):
         if total !=0:
@@ -43,38 +46,36 @@ class BackupTasks(BaseTasks):
                     zipf.write(os.path.join(root, file), arcname=os.path.join(root, file).replace(filename, ''))
                     self.update_progress_bar(i, len(all_files))
                     i = i + 1
-
+                    
     def move_file(self, src, dst, copy=False, ignore=None):
-        all_files = []
-        for root, dirs, files in os.walk(src):
-            for file in files:
-                all_files.append((os.path.join(root, file), os.path.join(dst, os.path.relpath(root, src))))
+        number_of_files = 0
+        current_file_index = 0
 
-        total_files = len(all_files)
+        def count_files_copy_function(src, dst):
+            nonlocal number_of_files
+            number_of_files += 1
 
-        if copy:
-            operation = shutil.copy
-        else:
-            operation = shutil.move
+        def copy_function(src, dst):
+            nonlocal current_file_index
 
-        i = 0
-        for file, dest_dir in all_files:
+            if copy:
+                operation = shutil.copy
+            else:
+                operation = shutil.move
+
             try:
-                if not os.path.exists(dest_dir):
-                    os.makedirs(dest_dir)
-                # check if the file is in ignore copytree list and if so skip it
-                if os.path.exists(file):
-                    if ignore is not None:
-                        if not ignore(file, os.path.basename(file)):
-                            operation(file, os.path.join(dest_dir, os.path.basename(file)))
-                            i += 1
-                else:
-                    print(f"File not found: {file}")
+                operation(src, dst)
+            except PermissionError as e:
+                print(f"PermissionError: {e}")
             except Exception as e:
-                print(f"Error: {e}")
+                print(f"An unexpected error occurred: {e}")
 
-            self.update_progress_bar(i, total_files)
-        
+            current_file_index += 1
+            self.update_progress_bar(current_file_index, number_of_files)
+
+        shutil.copytree(src, dst, ignore=ignore, copy_function=count_files_copy_function)
+        shutil.copytree(src, dst, ignore=ignore, copy_function=copy_function, dirs_exist_ok=True)
+    
 
     def _check_backup_space(self, src):
         # Checks if there is enough space to move dir at src into the backup directory

--- a/installation_and_upgrade/ibex_install_utils/tasks/backup_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/backup_tasks.py
@@ -17,9 +17,6 @@ class BackupTasks(BaseTasks):
     # lowercase names of directories we are not worried about if they do
     # not exist for example Python which has been Python3 for some time
     FAILED_BACKUP_DIRS_TO_IGNORE = [ r'c:\instrument\apps\python' ]
-    number_of_files = 0
-    current_file_index = 0
-    temp_copy_bool = False
 
     def update_progress_bar(self,progress, total, width=20):
         if total !=0:


### PR DESCRIPTION
Forward the unused shutil ignore func to the `move_file` function and use the copytree function with the present move function as the copy_function param of the copytree function.