### PR TITLE
Merged counting of files and getting dir size

### DIFF
--- a/installation_and_upgrade/ibex_install_utils/file_utils.py
+++ b/installation_and_upgrade/ibex_install_utils/file_utils.py
@@ -5,6 +5,7 @@ Filesystem utility classes
 import binascii
 import os
 import shutil
+import tempfile
 import time
 import zlib
 from ibex_install_utils.exceptions import UserStop
@@ -203,7 +204,9 @@ class FileUtils:
             number_of_files += 1
             size_of_dir += os.path.getsize(src)
         
-        shutil.copytree(path, 'C:/data', ignore=ignore, copy_function=total_up_size, dirs_exist_ok=True)
+        temp_dir = tempfile.gettempdir()
+        backup_temp_dir = os.path.join(temp_dir, "copy_tree_temp_dir")
+        shutil.copytree(path, backup_temp_dir, ignore=ignore, copy_function=total_up_size, dirs_exist_ok=True)
         return size_of_dir, number_of_files
 
                 

--- a/installation_and_upgrade/ibex_install_utils/file_utils.py
+++ b/installation_and_upgrade/ibex_install_utils/file_utils.py
@@ -192,11 +192,20 @@ class FileUtils:
         return total
     
     @staticmethod
-    def get_size(path='.'):
-        if os.path.isfile(path):
-            return os.path.getsize(path)
-        elif os.path.isdir(path):
-            return FileUtils._get_dir_size(path)
+    def get_size_and_number_of_files(path='.', ignore=None):
+        # use copytree to get size of directory
+        size_of_dir = 0
+        number_of_files = 0
+
+        def total_up_size(src, dst):
+            nonlocal size_of_dir
+            nonlocal number_of_files
+            number_of_files += 1
+            size_of_dir += os.path.getsize(src)
+        
+        shutil.copytree(path, 'C:/data', ignore=ignore, copy_function=total_up_size, dirs_exist_ok=True)
+        return size_of_dir, number_of_files
+
                 
     @staticmethod
     def dehex_and_decompress(value):

--- a/installation_and_upgrade/ibex_install_utils/tasks/backup_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/backup_tasks.py
@@ -83,9 +83,10 @@ class BackupTasks(BaseTasks):
         # (all in bytes)
         _, _, free = shutil.disk_usage(BACKUP_DIR)
         backup_size, number_of_files = FileUtils.get_size_and_number_of_files(src, ignore=ignore)
-        if backup_size > free:
+        while backup_size > free:
             needed_space = round((backup_size - free) / (1024 ** 3), 2)
             self.prompt.prompt_and_raise_if_not_yes(f"You don't have enough space to backup. Free up {needed_space} GB at {BACKUP_DIR}")
+            _, _, free = shutil.disk_usage(BACKUP_DIR)
 
         return backup_size, number_of_files
 

--- a/installation_and_upgrade/ibex_install_utils/tasks/backup_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/backup_tasks.py
@@ -74,7 +74,7 @@ class BackupTasks(BaseTasks):
 
             current_file_index += 1
             self.update_progress_bar(current_file_index, number_of_files)
-            
+
         shutil.copytree(src, dst, ignore=ignore, copy_function=copy_function, dirs_exist_ok=True)
     
 
@@ -86,8 +86,8 @@ class BackupTasks(BaseTasks):
         if backup_size > free:
             needed_space = round((backup_size - free) / (1024 ** 3), 2)
             self.prompt.prompt_and_raise_if_not_yes(f"You don't have enough space to backup. Free up {needed_space} GB at {BACKUP_DIR}")
-        else:
-            return backup_size, number_of_files
+
+        return backup_size, number_of_files
 
     def _backup_dir(self, src, copy=True, ignore=None):
         backup_dir = os.path.join(self._get_backup_dir(), os.path.basename(src))


### PR DESCRIPTION
Using copytree to get a dir size meant using a custom copy function again and if we are looping through all the files we may as well count them while we do. Thus, I merged counting the dir's number of files into the function of getting the dir size. Otherwise we'd be looping through all a dir's files twice before actually copying/moving.