### PR TITLE
Make mysql delayed start

### DIFF
--- a/installation_and_upgrade/ibex_install_utils/tasks/mysql_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/mysql_tasks.py
@@ -221,7 +221,9 @@ class MysqlTasks(BaseTasks):
                                    .format(os.path.join(MYSQL_FILES_DIR, "data")))
 
         admin_commands.add_command("sc", "start MYSQL80", expected_return_val=None)
-        admin_commands.add_command("sc", "config MYSQL80 start= auto")
+        # we use "delayed-auto" for start= as we have some ibex installations where a required disk volume
+        # doesn't get mounted in time if just "auto" is used  
+        admin_commands.add_command("sc", "config MYSQL80 start= delayed-auto")
         admin_commands.add_command("sc",
                                    "failure MYSQL80 reset= 900 actions= restart/10000/restart/30000/restart/60000")
         admin_commands.add_command("sc", "failureflag MYSQL80 1")


### PR DESCRIPTION
Use `delayed-start` on service, needed on e.g. hifi-cryomag as disk volumes mounted late

# To Test

though you cannot run the upgrade script, as admin run the command it would run
```
sc config MYSQL80 start= delayed-auto
```
and check your mysql goes in `automatic (delayed start)` in the services display