### PR TITLE
Fix system tests by not setting up log rotation

### DIFF
--- a/installation_and_upgrade/ibex_install_utils/install_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/install_tasks.py
@@ -152,7 +152,6 @@ class UpgradeInstrument:
         self._client_tasks.install_ibex_client()
         self._server_tasks.upgrade_instrument_configuration()
         self._server_tasks.install_shared_scripts_repository()
-        self._server_tasks.setup_log_rotation()
 
     def run_instrument_tests(self):
         """Run through client and server tests once installation / deployment has completed."""


### PR DESCRIPTION
Fix the system tests as they run: 

(https://github.com/ISISComputingGroup/system_tests/blob/master/Jenkinsfile#L93)
`instrument_install_latest_build_only.bat` 

which in turn uses install_latest 
(https://github.com/ISISComputingGroup/ibex_utils/blob/master/installation_and_upgrade/instrument_install_latest_build_only.bat#L37C18-L37C32)

which then uses `install_latest` in installtasks.py  (https://github.com/ISISComputingGroup/ibex_utils/blob/master/installation_and_upgrade/ibex_install_utils/install_tasks.py#L382) 

which maps to `remove_all_and_install_client_and_server`
https://github.com/ISISComputingGroup/ibex_utils/blob/master/installation_and_upgrade/instrument_install_latest_build_only.bat#L37C18-L37C32
