### PR TITLE
8437 create network independent python venv

### DIFF
--- a/build_tools/check_builds_are_recent.bat
+++ b/build_tools/check_builds_are_recent.bat
@@ -1,5 +1,6 @@
 setlocal
-call "%~dp0..\installation_and_upgrade\define_latest_genie_python.bat" 3
+call "%~dp0..\installation_and_upgrade\define_latest_genie_python.bat"
 set PYTHONUNBUFFERED=TRUE
 REM use LATEST_PYTHON3 so not killed by stop_ibex_server 
 call "%LATEST_PYTHON3%" -u "%~dp0check_builds_are_recent.py"
+call "%~dp0remove_genie_python.bat" %LATEST_PYTHON_DIR%

--- a/build_tools/purge_archive.bat
+++ b/build_tools/purge_archive.bat
@@ -1,22 +1,22 @@
 setlocal EnableDelayedExpansion
 REM Remove old builds from the archive
-call "%~dp0..\installation_and_upgrade\define_latest_genie_python.bat" 3
 
 if not "%WORKSPACE%" == "" (
     if exist "%WORKSPACE%\Python3" rd /s /q %WORKSPACE%\Python3
-    call %LATEST_PYTHON_DIR%..\genie_python_install.bat %WORKSPACE%\Python3
     if !errorlevel! neq 0 exit /b 1
-    set "LATEST_PYTHON3=%WORKSPACE%\Python3\python3.exe"
 )
 
+call "%~dp0..\installation_and_upgrade\define_latest_genie_python.bat" %WORKSPACE%\Python3
+
 set PYTHONUNBUFFERED=TRUE
-REM use LATEST_PYTHON3 to avoid process being killed 
+REM use LATEST_PYTHON3 to avoid process being killed
 "%LATEST_PYTHON3%" -u "%~dp0purge_archive.py"
 set errcode=!errorlevel!
 @echo purge_archive.py exited with code !errcode!
 for /F "skip=1" %%I in ('wmic path win32_localtime get dayofweek') do (set /a DOW=%%I 2>NUL)
 if %DOW% neq 6 (
     @echo Skipping debug symbol cleanup as day of week %DOW% is not 6
+    CALL "%~dp0..\installation_and_upgrade\remove_genie_python.bat" %LATEST_PYTHON_DIR%
     exit /b !errcode!
 )
 REM Remove old debug symbols from the archive
@@ -33,3 +33,5 @@ if exist "%AGESTORE%" (
 ) else (
     @echo agestore does not exist
 )
+
+CALL "%~dp0..\installation_and_upgrade\remove_genie_python.bat" %LATEST_PYTHON_DIR%

--- a/installation_and_upgrade/define_latest_genie_python.bat
+++ b/installation_and_upgrade/define_latest_genie_python.bat
@@ -14,8 +14,13 @@ set "genie_dir=%KITS_ICP_PATH%\genie_python_3"
 if exist "%genie_dir%\LATEST_BUILD.txt" (
 
 	for /f %%i in ( %genie_dir%\LATEST_BUILD.txt ) do (
-	
-		set "LATEST_PYTHON_DIR=%tmp%\Python_Build_%%i" 
+
+		if "%~1" NEQ "" (
+			set "LATEST_PYTHON_DIR=%~1\Python_Build_%%i" 
+		) else (
+			set "LATEST_PYTHON_DIR=%tmp%\Python_Build_%%i"
+		)
+		
 		mkdir !LATEST_PYTHON_DIR!
 	
 		%genie_dir%\BUILD-%%i\genie_python_install.bat !LATEST_PYTHON_DIR!

--- a/installation_and_upgrade/define_latest_genie_python.bat
+++ b/installation_and_upgrade/define_latest_genie_python.bat
@@ -1,5 +1,4 @@
 @echo off
-setlocal enabledelayedexpansion
 REM Get latest python build and kits icp path
 REM KITS_ICP_PATH is set to ICP directory
 REM LATEST_PYTHON is set to a version on genie_python that can be run
@@ -15,19 +14,8 @@ if exist "%genie_dir%\LATEST_BUILD.txt" (
 
 	for /f %%i in ( %genie_dir%\LATEST_BUILD.txt ) do (
 
-		if "%~1" NEQ "" (
-			set "LATEST_PYTHON_DIR=%~1\Python_Build_%%i" 
-		) else (
-			set "LATEST_PYTHON_DIR=%tmp%\Python_Build_%%i"
-		)
+		set PYTHON_BUILD_NO=%%i
 
-		mkdir !LATEST_PYTHON_DIR!
-	
-		%genie_dir%\BUILD-%%i\genie_python_install.bat !LATEST_PYTHON_DIR!
-		
-	    set "LATEST_PYTHON=!LATEST_PYTHON_DIR!\python.exe"
-	    set "LATEST_PYTHON3=!LATEST_PYTHON_DIR!\python3.exe"
-		
 	)
 	
 ) else (
@@ -36,6 +24,19 @@ if exist "%genie_dir%\LATEST_BUILD.txt" (
 	goto ERROR
 	
 )
+
+if "%~1" NEQ "" (
+	set "LATEST_PYTHON_DIR=%~1\Python_Build_%PYTHON_BUILD_NO%" 
+) else (
+	set "LATEST_PYTHON_DIR=%tmp%\Python_Build_%PYTHON_BUILD_NO%"
+)
+
+mkdir %LATEST_PYTHON_DIR%
+
+%genie_dir%\BUILD-%PYTHON_BUILD_NO%\genie_python_install.bat %LATEST_PYTHON_DIR%
+			
+set "LATEST_PYTHON=%LATEST_PYTHON_DIR%\python.exe"
+set "LATEST_PYTHON3=%LATEST_PYTHON_DIR%\python3.exe"
 
 rem @echo LATEST PYTHON: %LATEST_PYTHON%
 

--- a/installation_and_upgrade/define_latest_genie_python.bat
+++ b/installation_and_upgrade/define_latest_genie_python.bat
@@ -20,13 +20,13 @@ if exist "%genie_dir%\LATEST_BUILD.txt" (
 		) else (
 			set "LATEST_PYTHON_DIR=%tmp%\Python_Build_%%i"
 		)
-		
+
 		mkdir !LATEST_PYTHON_DIR!
 	
 		%genie_dir%\BUILD-%%i\genie_python_install.bat !LATEST_PYTHON_DIR!
 		
-	    set LATEST_PYTHON=!LATEST_PYTHON_DIR!\python.exe
-	    set LATEST_PYTHON3=!LATEST_PYTHON_DIR!\python3.exe
+	    set "LATEST_PYTHON=!LATEST_PYTHON_DIR!\python.exe"
+	    set "LATEST_PYTHON3=!LATEST_PYTHON_DIR!\python3.exe"
 		
 	)
 	

--- a/installation_and_upgrade/define_latest_genie_python.bat
+++ b/installation_and_upgrade/define_latest_genie_python.bat
@@ -7,22 +7,25 @@ REM	Fetch newest python build from \\isis\inst$\Kits$\CompGroup\ICP\genie_python
 REM Use genie_python_install to install it into a temporary directory
 REM Need to make sure that after every use of this bat that these variables are undefined and the temp dir is removed
 
+
 set "KITS_ICP_PATH=\\isis.cclrc.ac.uk\inst$\Kits$\CompGroup\ICP"
 set "genie_dir=%KITS_ICP_PATH%\genie_python_3"
+set "latest_build_file=%genie_dir%\LATEST_BUILD.txt"
 
-if exist "%genie_dir%\LATEST_BUILD.txt" (
+set "PYTHON_BUILD_NO="
 
+if exist "%genie_dir%\LATEST_BUILD.txt" (	
 	for /f %%i in ( %genie_dir%\LATEST_BUILD.txt ) do (
-
 		set PYTHON_BUILD_NO=%%i
-
 	)
-	
 ) else (
-
 	@echo Could not access LATEST_BUILD.txt
 	goto ERROR
-	
+)
+
+if "%PYTHON_BUILD_NO%" == "" (
+	@echo invalid LATEST_BUILD.txt
+	goto ERROR
 )
 
 if "%~1" NEQ "" (

--- a/installation_and_upgrade/define_latest_genie_python.bat
+++ b/installation_and_upgrade/define_latest_genie_python.bat
@@ -1,4 +1,5 @@
 @echo off
+setlocal enabledelayedexpansion
 REM Get latest python build and kits icp path
 REM KITS_ICP_PATH is set to ICP directory
 REM LATEST_PYTHON is set to a version on genie_python that can be run
@@ -8,20 +9,19 @@ REM Use genie_python_install to install it into a temporary directory
 REM Need to make sure that after every use of this bat that these variables are undefined and the temp dir is removed
 
 set "KITS_ICP_PATH=\\isis.cclrc.ac.uk\inst$\Kits$\CompGroup\ICP"
-
 set "genie_dir=%KITS_ICP_PATH%\genie_python_3"
 
 if exist "%genie_dir%\LATEST_BUILD.txt" (
 
 	for /f %%i in ( %genie_dir%\LATEST_BUILD.txt ) do (
 	
-		set LATEST_PYTHON_DIR=%tmp%\Python_Build_%%i
-		mkdir %LATEST_PYTHON_DIR%
+		set "LATEST_PYTHON_DIR=%tmp%\Python_Build_%%i" 
+		mkdir !LATEST_PYTHON_DIR!
 	
-		CALL %genie_dir%\BUILD-%%i\genie_python_install.bat %LATEST_PYTHON_DIR%
+		%genie_dir%\BUILD-%%i\genie_python_install.bat !LATEST_PYTHON_DIR!
 		
-	    set LATEST_PYTHON=%LATEST_PYTHON_DIR%\python.exe
-	    set LATEST_PYTHON3=%LATEST_PYTHON_DIR%\python3.exe
+	    set LATEST_PYTHON=!LATEST_PYTHON_DIR!\python.exe
+	    set LATEST_PYTHON3=!LATEST_PYTHON_DIR!\python3.exe
 		
 	)
 	

--- a/installation_and_upgrade/define_latest_genie_python.bat
+++ b/installation_and_upgrade/define_latest_genie_python.bat
@@ -1,24 +1,38 @@
 @echo off
 REM Get latest python build and kits icp path
-REM   KITS_ICP_PATH is set to ICP directory
-REM   LATEST_PYTHON is set to a version on genie_python that can be run
+REM KITS_ICP_PATH is set to ICP directory
+REM LATEST_PYTHON is set to a version on genie_python that can be run
+
+REM	Fetch newest python build from \\isis\inst$\Kits$\CompGroup\ICP\genie_python_3
+REM Use genie_python_install to install it into a temporary directory
+REM Need to make sure that after every use of this bat that these variables are undefined and the temp dir is removed
 
 set "KITS_ICP_PATH=\\isis.cclrc.ac.uk\inst$\Kits$\CompGroup\ICP"
 
-set "GENIE_DIR=%KITS_ICP_PATH%\genie_python_3"
+set "genie_dir=%KITS_ICP_PATH%\genie_python_3"
 
-if exist "%GENIE_DIR%\LATEST_BUILD.txt" (
-	for /f %%i in ( %GENIE_DIR%\LATEST_BUILD.txt ) do (
-	    set LATEST_PYTHON_DIR=%GENIE_DIR%\BUILD-%%i\Python\
-	    set LATEST_PYTHON=%GENIE_DIR%\BUILD-%%i\Python\python.exe
-	    set LATEST_PYTHON3=%GENIE_DIR%\BUILD-%%i\Python\python3.exe
+if exist "%genie_dir%\LATEST_BUILD.txt" (
+
+	for /f %%i in ( %genie_dir%\LATEST_BUILD.txt ) do (
+	
+		set LATEST_PYTHON_DIR=%tmp%\Python_Build_%%i
+		mkdir %LATEST_PYTHON_DIR%
+	
+		CALL %genie_dir%\BUILD-%%i\genie_python_install.bat %LATEST_PYTHON_DIR%
+		
+	    set LATEST_PYTHON=%LATEST_PYTHON_DIR%\python.exe
+	    set LATEST_PYTHON3=%LATEST_PYTHON_DIR%\python3.exe
+		
 	)
+	
 ) else (
+
 	@echo Could not access LATEST_BUILD.txt
 	goto ERROR
+	
 )
 
-@echo LATEST PYTHON: %LATEST_PYTHON%
+rem @echo LATEST PYTHON: %LATEST_PYTHON%
 
 exit /b 0
 

--- a/installation_and_upgrade/developer_update.bat
+++ b/installation_and_upgrade/developer_update.bat
@@ -1,6 +1,6 @@
-setlocal
+setlocal EnableDelayedExpansion
 set "SOURCE=\\isis.cclrc.ac.uk\inst$\Kits$\CompGroup\ICP\Releases"
-call "%~dp0\define_latest_genie_python.bat"
+call "%~dp0define_latest_genie_python.bat"
 
 set "STOP_IBEX=C:\Instrument\Apps\EPICS\stop_ibex_server"
 set "START_IBEX=C:\Instrument\Apps\EPICS\start_ibex_server"
@@ -8,6 +8,11 @@ set "START_IBEX=C:\Instrument\Apps\EPICS\start_ibex_server"
 start /wait cmd /c "%STOP_IBEX%"
 
 call "%LATEST_PYTHON%" "%~dp0IBEX_upgrade.py" --release_dir "%SOURCE%" --release_suffix "%SUFFIX%" --confirm_step developer_update
-IF ERRORLEVEL 1 EXIT /b %errorlevel%
+IF ERRORLEVEL 1 (
+  set errcode = %ERRORLEVEL%
+  call "%~dp0remove_genie_python.bat" %LATEST_PYTHON_DIR%
+  EXIT /b !errcode!
+)
 
 start /wait cmd /c "%START_IBEX%"
+call "%~dp0remove_genie_python.bat" %LATEST_PYTHON_DIR%

--- a/installation_and_upgrade/instrument_deploy.bat
+++ b/installation_and_upgrade/instrument_deploy.bat
@@ -79,7 +79,7 @@ REM Set python as share just for script call
 call "%~dp0define_latest_genie_python.bat"
 IF %errorlevel% neq 0 exit /b %errorlevel%
 if not exist "%LATEST_PYTHON%" (
-    @echo Cannot find python on network share
+    @echo Cannot install python from network share
     goto ERROR
 )
 
@@ -102,5 +102,10 @@ set "PYTHONHOME=%LATEST_PYTHON_DIR%"
 set "PYTHONPATH=%LATEST_PYTHON_DIR%"
 
 call "%LATEST_PYTHON%" "%~dp0IBEX_upgrade.py" --release_dir "%SOURCE%" --release_suffix "%SUFFIX%" --server_arch %SERVER_ARCH% --confirm_step instrument_deploy_post_start
+call "%~dp0remove_genie_python.bat" %LATEST_PYTHON_DIR%
+
+exit /b 0
+
 :ERROR
+call "%~dp0remove_genie_python.bat" %LATEST_PYTHON_DIR%
 EXIT /b 1

--- a/installation_and_upgrade/instrument_install.bat
+++ b/installation_and_upgrade/instrument_install.bat
@@ -2,11 +2,11 @@ setlocal
 
 REM check if console has Administrative privileges
 call "%~dp0check_for_admin_console.bat"
-IF %errorlevel% neq 0 EXIT /b %errorlevel%
+if %errorlevel% neq 0 goto ERROR
 
 set "SOURCE=\\isis.cclrc.ac.uk\inst$\Kits$\CompGroup\ICP\Releases"
-call "%~dp0\define_latest_genie_python.bat"
-IF %errorlevel% neq 0 EXIT /b %errorlevel%
+call "%~dp0define_latest_genie_python.bat"
+if %errorlevel% neq 0 goto ERROR
 
 set SERVER_ARCH=x64
 if not "%1" == "" set SERVER_ARCH=%1
@@ -24,7 +24,7 @@ if not exist "%SOURCE%" (
 git --version
 IF %errorlevel% neq 0 (
     echo No installation of Git found on machine. Please download Git from https://git-scm.com/downloads before proceeding.
-    EXIT /b %errorlevel%
+    goto ERROR
 )
 
 set "STOP_IBEX=C:\Instrument\Apps\EPICS\stop_ibex_server"
@@ -38,7 +38,15 @@ set "PYTHONHOME=%LATEST_PYTHON_DIR%"
 set "PYTHONPATH=%LATEST_PYTHON_DIR%"
 
 call "%LATEST_PYTHON%" "%~dp0IBEX_upgrade.py" --release_dir "%SOURCE%" --release_suffix "%SUFFIX%" --server_arch %SERVER_ARCH% --confirm_step instrument_install
-IF %errorlevel% neq 0 EXIT /b %errorlevel%
+if %errorlevel% neq 0 goto ERROR
 ENDLOCAL
 
 start /wait cmd /c "%START_IBEX%"
+
+call "%~dp0remove_genie_python.bat" %LATEST_PYTHON_DIR%
+exit /b 0
+
+:ERROR
+set errcode = %ERRORLEVEL%
+call "%~dp0remove_genie_python.bat" %LATEST_PYTHON_DIR%
+EXIT /b !errcode!

--- a/installation_and_upgrade/instrument_install_latest_build_only.bat
+++ b/installation_and_upgrade/instrument_install_latest_build_only.bat
@@ -10,7 +10,7 @@ setlocal EnableDelayedExpansion
 
 set PYTHONUNBUFFERED=TRUE
 
-call "%~dp0\define_latest_genie_python.bat"
+call "%~dp0define_latest_genie_python.bat"
 IF %errorlevel% neq 0 (
     @echo Failed to define genie python
     GOTO ERROR
@@ -81,8 +81,10 @@ IF %errorlevel% neq 0 (
     GOTO ERROR
 )
 
+call "%~dp0remove_genie_python.bat" %LATEST_PYTHON_DIR%
 GOTO :EOF
 
 :ERROR
 echo Error on Install
+call "%~dp0remove_genie_python.bat" %LATEST_PYTHON_DIR%
 exit /b 2

--- a/installation_and_upgrade/instrument_save_settings.bat
+++ b/installation_and_upgrade/instrument_save_settings.bat
@@ -1,7 +1,7 @@
 setlocal
 set "SOURCE=\\isis.cclrc.ac.uk\inst$\Kits$\CompGroup\ICP\Releases"
 call "%~dp0define_latest_genie_python.bat"
-IF %errorlevel% neq 0 EXIT /b %errorlevel%
+if %errorlevel% neq 0 goto ERROR
 call C:\Instrument\Apps\EPICS\config_env.bat
 set "PYTHONDIR=%LATEST_PYTHON_DIR%"
 set "PYTHONHOME=%LATEST_PYTHON_DIR%"
@@ -11,4 +11,12 @@ set "PYTHONPATH=%LATEST_PYTHON_DIR%"
 @echo *** IBEX should still be running at this point
 @echo.
 call "%LATEST_PYTHON%" -u "%~dp0IBEX_upgrade.py" --release_dir "%SOURCE%" --confirm_step instrument_deploy_pre_stop
-IF %errorlevel% neq 0 EXIT /b %errorlevel%
+if %errorlevel% neq 0 goto ERROR
+
+call "%~dp0remove_genie_python.bat" %LATEST_PYTHON_DIR%
+exit /b 0
+
+:ERROR
+set errcode = %ERRORLEVEL%
+call "%~dp0remove_genie_python.bat" %LATEST_PYTHON_DIR%
+EXIT /b !errcode!

--- a/installation_and_upgrade/instrument_test.bat
+++ b/installation_and_upgrade/instrument_test.bat
@@ -1,6 +1,14 @@
 set "SOURCE=\\isis.cclrc.ac.uk\inst$\Kits$\CompGroup\ICP\Releases"
-call "%~dp0\define_latest_genie_python.bat"
-IF %errorlevel% neq 0 EXIT /b %errorlevel%
+call "%~dp0define_latest_genie_python.bat"
+if %errorlevel% neq 0 goto ERROR
 
 call "%LATEST_PYTHON%" "%~dp0IBEX_upgrade.py" --release_dir "%SOURCE%" --confirm_step instrument_test
-IF %errorlevel% neq 0 EXIT /b %errorlevel%
+if %errorlevel% neq 0 goto ERROR
+
+call "%~dp0remove_genie_python.bat" %LATEST_PYTHON_DIR%
+exit /b 0
+
+:ERROR
+set errcode = %ERRORLEVEL%
+call "%~dp0remove_genie_python.bat" %LATEST_PYTHON_DIR%
+EXIT /b !errcode!

--- a/installation_and_upgrade/instrument_update.bat
+++ b/installation_and_upgrade/instrument_update.bat
@@ -1,6 +1,6 @@
 setlocal
-call "%~dp0\define_latest_genie_python.bat"
-if %errorlevel% neq 0 exit /b %errorlevel%
+call "%~dp0define_latest_genie_python.bat"
+if %errorlevel% neq 0 goto ERROR
 set "SOURCE=\\isis.cclrc.ac.uk\inst$\Kits$\CompGroup\ICP\Releases\4.0.0"
 
 set "STOP_IBEX=C:\Instrument\Apps\EPICS\stop_ibex_server"
@@ -8,6 +8,13 @@ set "START_IBEX=C:\Instrument\Apps\EPICS\start_ibex_server"
 IF EXIST "C:\Instrument\Apps\EPICS" (start /wait cmd /c "%STOP_IBEX%")
 
 call "%LATEST_PYTHON%" "%~dp0IBEX_upgrade.py" --release_dir "%SOURCE%" --confirm_step instrument_update
-if %errorlevel% neq 0 exit /b %errorlevel%
-
+if %errorlevel% neq 0 goto ERROR
 start /wait cmd /c "%START_IBEX%"
+
+call "%~dp0remove_genie_python.bat" %LATEST_PYTHON_DIR%
+exit /b 0
+
+:ERROR
+set errcode = %ERRORLEVEL%
+call "%~dp0remove_genie_python.bat" %LATEST_PYTHON_DIR%
+EXIT /b !errcode!

--- a/installation_and_upgrade/remove_genie_python.bat
+++ b/installation_and_upgrade/remove_genie_python.bat
@@ -11,18 +11,18 @@ set modified_path=%path:%substring%=%
 
 if "%path%" neq "%modified_path%" (
 
-    RMDIR /S /Q %path% && @echo Successfully removed %path%.
+    RMDIR /S /Q %path%
 
     set LATEST_PYTHON_DIR=
     set LATEST_PYTHON=
     set LATEST_PYTHON3=
-
 
 ) else (
     @echo Could not find the specified path: %path%.
     goto ERROR
 )
 
+@echo Successfully removed %path% and unset genie build variables.
 exit /b 0
 
 :ERROR

--- a/installation_and_upgrade/remove_genie_python.bat
+++ b/installation_and_upgrade/remove_genie_python.bat
@@ -1,8 +1,8 @@
 @echo off
 
 if "%~1"=="" (
-    echo No path provided as the first parameter.
-    exit /b 1
+    @echo No path provided as the first parameter.
+    goto ERROR
 )
 
 set substring=Python_Build_
@@ -10,13 +10,21 @@ set path=%~1
 set modified_path=%path:%substring%=%
 
 if "%path%" neq "%modified_path%" (
-    
+
+    RMDIR /S /Q %path% && @echo Successfully removed %path%.
+
     set LATEST_PYTHON_DIR=
     set LATEST_PYTHON=
     set LATEST_PYTHON3=
 
-    RMDIR /S /Q %path%
 
 ) else (
-    echo Could not find the specified path: %path%.
+    @echo Could not find the specified path: %path%.
+    goto ERROR
 )
+
+exit /b 0
+
+:ERROR
+@echo remove_genie_python failed
+exit /b 1

--- a/installation_and_upgrade/remove_genie_python.bat
+++ b/installation_and_upgrade/remove_genie_python.bat
@@ -1,0 +1,22 @@
+@echo off
+
+if "%~1"=="" (
+    echo No path provided as the first parameter.
+    exit /b 1
+)
+
+set substring=Python_Build_
+set path=%~1
+set modified_path=%path:%substring%=%
+
+if "%path%" neq "%modified_path%" (
+    
+    set LATEST_PYTHON_DIR=
+    set LATEST_PYTHON=
+    set LATEST_PYTHON3=
+
+    RMDIR /S /Q %path%
+
+) else (
+    echo Could not find the specified path: %path%.
+)

--- a/installation_and_upgrade/run_standalone_backup.bat
+++ b/installation_and_upgrade/run_standalone_backup.bat
@@ -1,9 +1,10 @@
 @ECHO OFF
 setlocal
 set "SOURCE=\\isis.cclrc.ac.uk\inst$\Kits$\CompGroup\ICP\Releases"
-call "%~dp0\define_latest_genie_python.bat"
+call "%~dp0define_latest_genie_python.bat"
 call cd "%~dp0"
 set PYTHONPATH=.
 @REM Uses Python from the Shares, set as LATEST_PYTHON
 call "%LATEST_PYTHON%" "%~dp0ibex_install_utils\tasks\backup_tasks.py"
+call "%~dp0remove_genie_python.bat" %LATEST_PYTHON_DIR%
 endlocal

--- a/installation_and_upgrade/save_motor_params.bat
+++ b/installation_and_upgrade/save_motor_params.bat
@@ -1,7 +1,16 @@
-setlocal
+setlocal EnableDelayedExpansion
 set "SOURCE=\\isis.cclrc.ac.uk\inst$\Kits$\CompGroup\ICP\Releases"
-call "%~dp0\define_latest_genie_python.bat"
-IF %errorlevel% neq 0 EXIT /b %errorlevel%
+call "%~dp0define_latest_genie_python.bat"
+IF %errorlevel% neq 0 goto ERROR
 
 call "%LATEST_PYTHON%" "%~dp0IBEX_upgrade.py" --release_dir "%SOURCE%" --confirm_step save_motor_params
-IF %errorlevel% neq 0 EXIT /b %errorlevel%
+
+IF %errorlevel% neq 0 goto ERROR
+
+call "%~dp0remove_genie_python.bat" %LATEST_PYTHON_DIR%
+exit /b 0
+
+:ERROR
+    set errcode = %ERRORLEVEL%
+    call "%~dp0remove_genie_python.bat" %LATEST_PYTHON_DIR%
+    EXIT /b !errcode!

--- a/installation_and_upgrade/truncate_database.bat
+++ b/installation_and_upgrade/truncate_database.bat
@@ -1,13 +1,22 @@
+setlocal EnableDelayedExpansion
 set "SOURCE=\\isis.cclrc.ac.uk\inst$\Kits$\CompGroup\ICP\Releases"
-call "%~dp0\define_latest_genie_python.bat"
-IF %errorlevel% neq 0 EXIT /b %errorlevel%
+call "%~dp0define_latest_genie_python.bat"
+IF %errorlevel% neq 0 goto ERROR
 
 git --version
 
 IF %errorlevel% neq 0 (
     echo No installation of Git found on machine. Please download Git from https://git-scm.com/downloads before proceeding.
-    EXIT /b %errorlevel%
+    goto ERROR
 )
 
 call "%LATEST_PYTHON%" "%~dp0IBEX_upgrade.py" --release_dir "%SOURCE%" --release_suffix "%SUFFIX%" --confirm_step truncate_database
-IF %errorlevel% neq 0 EXIT /b %errorlevel%
+IF %errorlevel% neq 0 goto ERROR
+call "%~dp0remove_genie_python.bat" %LATEST_PYTHON_DIR%
+
+exit /b 0
+
+:ERROR
+set errcode = %ERRORLEVEL%
+call "%~dp0remove_genie_python.bat" %LATEST_PYTHON_DIR%
+EXIT /b !errcode!

--- a/installation_and_upgrade/upgrade_mysql.bat
+++ b/installation_and_upgrade/upgrade_mysql.bat
@@ -1,4 +1,4 @@
-setlocal
+setlocal EnableDelayedExpansion
 set "SOURCE=\\isis.cclrc.ac.uk\inst$\Kits$\CompGroup\ICP\Releases"
 call "%~dp0define_latest_genie_python.bat"
 
@@ -8,6 +8,12 @@ set "START_IBEX=C:\Instrument\Apps\EPICS\start_ibex_server"
 start /wait cmd /c "%STOP_IBEX%"
 
 call "%LATEST_PYTHON%" -u "%~dp0IBEX_upgrade.py" --release_dir "%SOURCE%" --release_suffix "%SUFFIX%" --confirm_step force_upgrade_mysql
-IF %errorlevel% neq 0 EXIT /b %errorlevel%
+
+IF %errorlevel% neq 0 (
+    set errcode = %ERRORLEVEL%
+    call "%~dp0remove_genie_python.bat" %LATEST_PYTHON_DIR%
+    EXIT /b !errcode!
+)
 
 start /wait cmd /c "%START_IBEX%"
+call "%~dp0remove_genie_python.bat" %LATEST_PYTHON_DIR%

--- a/installation_and_upgrade/vhd_build.bat
+++ b/installation_and_upgrade/vhd_build.bat
@@ -1,10 +1,17 @@
+setlocal EnableDelayedExpansion
 set PYTHONUNBUFFERED=1
 set "SOURCE=\\isis.cclrc.ac.uk\inst$\Kits$\CompGroup\ICP\Releases"
-call "%~dp0\define_latest_genie_python.bat"
+call "%~dp0define_latest_genie_python.bat"
 
 IF EXIST "C:\Instrument\Apps\EPICS\stop_ibex_server.bat" (
   start /wait cmd /c "C:\Instrument\Apps\EPICS\stop_ibex_server.bat"
 )
 
 call "%LATEST_PYTHON%" "%~dp0IBEX_upgrade.py" --kits_icp_dir "%KITS_ICP_PATH%" create_vhds --quiet --no_log_to_var
-IF %ERRORLEVEL% NEQ 0 EXIT /b %errorlevel%
+IF %ERRORLEVEL% NEQ 0 (
+  set errcode = %ERRORLEVEL%
+  call "%~dp0remove_genie_python.bat" %LATEST_PYTHON_DIR%
+  EXIT /b !errcode!
+)
+
+call "%~dp0remove_genie_python.bat" %LATEST_PYTHON_DIR%

--- a/installation_and_upgrade/vhd_build_force_cleanup.bat
+++ b/installation_and_upgrade/vhd_build_force_cleanup.bat
@@ -1,10 +1,18 @@
+setlocal EnableDelayedExpansion
 set PYTHONUNBUFFERED=1
 set "SOURCE=\\isis.cclrc.ac.uk\inst$\Kits$\CompGroup\ICP\Releases"
-call "%~dp0\define_latest_genie_python.bat"
+call "%~dp0define_latest_genie_python.bat"
 
 IF EXIST "C:\Instrument\Apps\EPICS\stop_ibex_server.bat" (
   start /wait cmd /c "C:\Instrument\Apps\EPICS\stop_ibex_server.bat"
 )
 
 call "%LATEST_PYTHON%" "%~dp0IBEX_upgrade.py" --kits_icp_dir "%KITS_ICP_PATH%" request_dismount_vhds --quiet --no_log_to_var
-IF %ERRORLEVEL% NEQ 0 EXIT /b %errorlevel%
+
+IF %ERRORLEVEL% NEQ 0 (
+  set errcode = %ERRORLEVEL%
+  call "%~dp0remove_genie_python.bat" %LATEST_PYTHON_DIR%
+  EXIT /b !errcode!
+)
+
+call "%~dp0remove_genie_python.bat" %LATEST_PYTHON_DIR%

--- a/installation_and_upgrade/vhd_build_release.bat
+++ b/installation_and_upgrade/vhd_build_release.bat
@@ -1,11 +1,18 @@
-setlocal
+setlocal EnableDelayedExpansion
 set PYTHONUNBUFFERED=1
 set "SOURCE=\\isis.cclrc.ac.uk\inst$\Kits$\CompGroup\ICP\Releases"
-call "%~dp0\define_latest_genie_python.bat"
+call "%~dp0define_latest_genie_python.bat"
 
 IF EXIST "C:\Instrument\Apps\EPICS\stop_ibex_server.bat" (
   start /wait cmd /c "C:\Instrument\Apps\EPICS\stop_ibex_server.bat"
 )
 
 call "%LATEST_PYTHON%" -u "%~dp0IBEX_upgrade.py" --release_dir "%SOURCE%" create_vhds --quiet --no_log_to_var
-IF %ERRORLEVEL% NEQ 0 EXIT /b %errorlevel%
+
+IF %ERRORLEVEL% NEQ 0 (
+  set errcode = %ERRORLEVEL%
+  call "%~dp0remove_genie_python.bat" %LATEST_PYTHON_DIR%
+  EXIT /b !errcode!
+)
+
+call "%~dp0remove_genie_python.bat" %LATEST_PYTHON_DIR%


### PR DESCRIPTION
- Whenever `define_latest_genie_python.bat` is called, a python build is installed under `%tmp%\Python_Build_xxxx\`, or if a path is passed to define_latest_genie_python then it will install it under that path.
- Creates a new batch file `remove_genie_python.bat` which takes a path of where python is installs- it will uninstall it then undefine the global variables set in  `define_latest_genie_python.bat`.
- Made adjustments to every file referencing  `define_latest_genie_python.bat` so that it calls `remove_genie_python.bat` after the local python build has been used.

This should be merged before any other PR relating to this ticket.