### PR TITLE
Fixes genie python install variables

### DIFF
--- a/installation_and_upgrade/define_latest_genie_python.bat
+++ b/installation_and_upgrade/define_latest_genie_python.bat
@@ -36,12 +36,10 @@ if "%~1" NEQ "" (
 
 mkdir %LATEST_PYTHON_DIR%
 
-%genie_dir%\BUILD-%PYTHON_BUILD_NO%\genie_python_install.bat %LATEST_PYTHON_DIR%
+CALL %genie_dir%\BUILD-%PYTHON_BUILD_NO%\genie_python_install.bat %LATEST_PYTHON_DIR%
 			
 set "LATEST_PYTHON=%LATEST_PYTHON_DIR%\python.exe"
 set "LATEST_PYTHON3=%LATEST_PYTHON_DIR%\python3.exe"
-
-rem @echo LATEST PYTHON: %LATEST_PYTHON%
 
 exit /b 0
 

--- a/installation_and_upgrade/remove_genie_python.bat
+++ b/installation_and_upgrade/remove_genie_python.bat
@@ -13,7 +13,7 @@ if exist %remove_genie_python_path% (
     REM Checks that "Python_Build_" is in the supplied filepath, so it is a python build.
     echo.%remove_genie_python_path% | findstr /C:"Python_Build_">nul && (
 
-        REM Deleted directory tree + quiet.
+        REM Deletes directory tree + quiet.
         RMDIR /S /Q %remove_genie_python_path%
 
         REM Unassigns environment variables.
@@ -26,6 +26,7 @@ if exist %remove_genie_python_path% (
 
     ) || (
         @echo "%remove_genie_python_path%" is not a python build directory.
+        goto ERROR
     )
 
 ) else (

--- a/installation_and_upgrade/remove_genie_python.bat
+++ b/installation_and_upgrade/remove_genie_python.bat
@@ -5,25 +5,33 @@ if "%~1"=="" (
     goto ERROR
 )
 
-set substring=Python_Build_
-set path=%~1
-set modified_path=%path:%substring%=%
+set remove_genie_python_path=%~1
 
-if "%path%" neq "%modified_path%" (
+REM Checks that supplied filepath exists.
+if exist %remove_genie_python_path% (
 
-    RMDIR /S /Q %path%
+    REM Checks that "Python_Build_" is in the supplied filepath, so it is a python build.
+    echo.%remove_genie_python_path% | findstr /C:"Python_Build_">nul && (
 
-    set LATEST_PYTHON_DIR=
-    set LATEST_PYTHON=
-    set LATEST_PYTHON3=
+        REM Deleted directory tree + quiet.
+        RMDIR /S /Q %remove_genie_python_path%
+
+        REM Unassigns environment variables.
+        set LATEST_PYTHON_DIR=
+        set LATEST_PYTHON=
+        set LATEST_PYTHON3=
+
+        @echo Successfully removed "%remove_genie_python_path%" and unset genie build variables. 
+        exit /b 0
+
+    ) || (
+        @echo "%remove_genie_python_path%" is not a python build directory.
+    )
 
 ) else (
-    @echo Could not find the specified path: %path%.
+    @echo Could not find the specified path: "%remove_genie_python_path%".
     goto ERROR
 )
-
-@echo Successfully removed %path% and unset genie build variables.
-exit /b 0
 
 :ERROR
 @echo remove_genie_python failed


### PR DESCRIPTION
Genie python was not getting installed properly because of a bug merged in https://github.com/ISISComputingGroup/IBEX/issues/8437 . This is fixed by instead calling `%genie_dir%\BUILD-%PYTHON_BUILD_NO%\genie_python_install.bat %LATEST_PYTHON_DIR%` which means that the following 
```
set "LATEST_PYTHON=%LATEST_PYTHON_DIR%\python.exe"
set "LATEST_PYTHON3=%LATEST_PYTHON_DIR%\python3.exe"
```
is executed. Also fixed problem in remote genie python, whereby `path` was being overwritten because of a poorly chosen variable name. 