### PR TITLE
Fixes define genie python

### DIFF
--- a/installation_and_upgrade/define_latest_genie_python.bat
+++ b/installation_and_upgrade/define_latest_genie_python.bat
@@ -29,9 +29,9 @@ if "%PYTHON_BUILD_NO%" == "" (
 )
 
 if "%~1" NEQ "" (
-	set "LATEST_PYTHON_DIR_T=%~1\Python_Build_%PYTHON_BUILD_NO%"
+	set "LATEST_PYTHON_DIR_T=%~1\Python_Build_%RANDOM%"
 ) else (
-	set "LATEST_PYTHON_DIR_T=%tmp%\Python_Build_%PYTHON_BUILD_NO%"
+	set "LATEST_PYTHON_DIR_T=%tmp%\Python_Build_%RANDOM%"
 )
 
 mkdir %LATEST_PYTHON_DIR_T%


### PR DESCRIPTION
Uses `random` instead of python build number as a directory to install python so that multiple python builds can be installed and used concurrently without permissions issues.