### PR TITLE
Update genie modules on non-release install (primarily for system tests)

### DIFF
--- a/installation_and_upgrade/instrument_install_latest_build_only.bat
+++ b/installation_and_upgrade/instrument_install_latest_build_only.bat
@@ -81,6 +81,14 @@ IF %errorlevel% neq 0 (
     GOTO ERROR
 )
 
+if not "%1" == "RELEASE" (
+    call "%~dp0update_genie_python_module.bat" C:\Instrument\Apps\Python3
+)
+IF %errorlevel% neq 0 (
+    echo Error %errorlevel% returned from update_genie_python_module.bat
+    GOTO ERROR
+)
+
 call "%~dp0remove_genie_python.bat" %LATEST_PYTHON_DIR%
 GOTO :EOF
 

--- a/installation_and_upgrade/update_genie_python_module.bat
+++ b/installation_and_upgrade/update_genie_python_module.bat
@@ -1,0 +1,8 @@
+setlocal
+set "PYTHONHOME=%1"
+set "PYTHONPATH=%PYTHONHOME%"
+@echo Updating %PYTHONHOME% to latest versions of genie_python and ibex_bluesky_core
+"%PYTHONHOME%\python.exe" -m pip install genie_python[plot]@git+https://github.com/IsisComputingGroup/genie.git@main
+if %errorlevel% NEQ 0 EXIT /B %errorlevel%
+"%PYTHONHOME%\python.exe" -m pip install ibex_bluesky_core@git+https://github.com/IsisComputingGroup/ibex_bluesky_core.git@main
+if %errorlevel% NEQ 0 EXIT /B %errorlevel%


### PR DESCRIPTION
Update the local genie python to latest master on a non-release install, this ensure we are testing most recent code  

Needed as https://github.com/ISISComputingGroup/system_tests/blob/0956009a2b255d0dec325701e5e6f320ab11f528/run_tests.bat#L5 just covers python running system tests code and not the ibex server running in the background 