### PR TITLE
genie uninstall: Kill caRepeater if running

### DIFF
--- a/installation_and_upgrade/remove_genie_python.bat
+++ b/installation_and_upgrade/remove_genie_python.bat
@@ -13,6 +13,10 @@ if exist "%remove_genie_python_path%" (
     REM Checks that "Python_Build_" is in the supplied filepath, so it is a python build.
     echo.%remove_genie_python_path% | findstr /C:"Python_Build_">nul && (
 
+        REM if caRepeater is running we can't remove directory
+        del /f "%remove_genie_python_path%\CaRepeater.exe"
+        if exist "%remove_genie_python_path%\CaRepeater.exe" taskkill /f /im CaRepeater.exe
+
         REM Deletes directory tree + quiet.
         RMDIR /S /Q %remove_genie_python_path%
 


### PR DESCRIPTION
Otherwise directory cannot be totally removed

I tried using `del` with `||` but it never gave correct exit code, hence current exists logic. Can't check errorlevel as inside if and `%` will not work, and can't use `!` as we can't `setlocal EnableDelayedExpansion` due to unsetting of external environment variables  in script