### PR TITLE
Set upstream on all local branches

### DIFF
--- a/installation_and_upgrade/ibex_install_utils/tasks/git_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/git_tasks.py
@@ -41,9 +41,26 @@ class GitTasks(BaseTasks):
 
         try:
             subprocess.check_call(f"cd /d {EPICS_PATH} && git fetch", shell=True)
-            print("Fetched remote")
+            print("Fetching from remote")
         except subprocess.CalledProcessError as e:
             print(f"Error fetching remote: {e}")
+
+        # this sets upstream tracking on all local branches not just current one
+        try:
+            subprocess.check_call(
+                f"cd /d {EPICS_PATH} && FOR /F \"delims=* \" %i IN ('git branch') "
+                "DO git branch --set-upstream-to=origin/%i %i",
+                shell=True,
+            )
+            print("Set branch upstream tracking")
+        except subprocess.CalledProcessError as e:
+            print(f"Error setting branch upstream tracking: {e}")
+
+        try:
+            subprocess.check_call(f"cd /d {EPICS_PATH} && git pull", shell=True)
+            print("Pulled current branch from remote")
+        except subprocess.CalledProcessError as e:
+            print(f"Error pulling from remote: {e}")
 
         try:
             # run a git status to rebuild index if needed

--- a/installation_and_upgrade/ibex_install_utils/tasks/git_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/git_tasks.py
@@ -45,6 +45,12 @@ class GitTasks(BaseTasks):
         except subprocess.CalledProcessError as e:
             print(f"Error fetching remote: {e}")
 
+        try:
+            # run a git status to rebuild index if needed
+            subprocess.check_call(f"cd /d {EPICS_PATH} && git status", shell=True)
+        except subprocess.CalledProcessError as e:
+            print(f"Error running git status: {e}")
+
         # this sets upstream tracking on all local branches not just current one
         try:
             subprocess.check_call(


### PR DESCRIPTION
This sets the upstream for all branches after an install and pulls before making local instrument branch, this ensures any hotfixes post build of release are immediately installed 