### PR TITLE
Setup python explicitly

### DIFF
--- a/.github/workflows/push_event_workflow.yml
+++ b/.github/workflows/push_event_workflow.yml
@@ -9,6 +9,11 @@ jobs:
     steps:
     - name : Checkout code
       uses : actions/checkout@v4
+
+    - name: Setup python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
      
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Setup python explicitly so that we get 3.11 (like on dev machines), rather than 3.9 which is default-installed on the CI runners if you don't request anything explicitly

I noticed this in https://github.com/ISISComputingGroup/ibex_utils/pull/221 where GHA said we weren't allowed to use `Callable | None`, but this is allowed on 3.11.