### PR TITLE
Start server in new env

### DIFF
--- a/installation_and_upgrade/instrument_deploy.bat
+++ b/installation_and_upgrade/instrument_deploy.bat
@@ -92,7 +92,7 @@ call "%LATEST_PYTHON%" "%~dp0IBEX_upgrade.py" --release_dir "%SOURCE%" --release
 IF %errorlevel% neq 0 exit /b %errorlevel%
 ENDLOCAL
 
-start /wait cmd /c "%START_IBEX%"
+start /i /wait cmd /c "%START_IBEX%"
 
 REM python should be installed correctly at this point, so use local python
 set "LATEST_PYTHON_DIR=C:\Instrument\Apps\Python3\"


### PR DESCRIPTION
Start server in new env at end of install to pick up new java path

To test principle used:

from an epics term type
```
start /i /wait cmd /c config_env.bat
```
you'll see test indicating script run

typing instead
```
start /wait cmd /c config_env.bat
```
terminates quickly as env inherited