### PR TITLE
Capture logrotate task output

### DIFF
--- a/installation_and_upgrade/ibex_install_utils/tasks/server_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/server_tasks.py
@@ -737,7 +737,7 @@ class ServerTasks(BaseTasks):
         logrotate = r"c:\instrument\apps\epics\utils\logrotate.py"
         task_cmd = (
             f"cmd.exe /c start /min {python} {logrotate} "
-            "> C:\Instrument\Var\logs\schtasks\logrotate.log 2>&1"
+            r"> C:\Instrument\Var\logs\schtasks\logrotate.log 2>&1"
         )
 
         admin_commands = AdminCommandBuilder()

--- a/installation_and_upgrade/ibex_install_utils/tasks/server_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/server_tasks.py
@@ -735,7 +735,7 @@ class ServerTasks(BaseTasks):
         """Sets up instrument log rotation via windows scheduled task."""
         python = r"c:\instrument\apps\python3\python.exe"
         logrotate = r"c:\instrument\apps\epics\utils\logrotate.py"
-        task_cmd = f"cmd.exe /c start /min {python} {logrotate}"
+        task_cmd = f"cmd.exe /c start /min {python} {logrotate} > C:\Instrument\Var\logs\schtasks\logrotate.log 2>&1"
 
         admin_commands = AdminCommandBuilder()
         admin_commands.add_command(

--- a/installation_and_upgrade/ibex_install_utils/tasks/server_tasks.py
+++ b/installation_and_upgrade/ibex_install_utils/tasks/server_tasks.py
@@ -735,7 +735,10 @@ class ServerTasks(BaseTasks):
         """Sets up instrument log rotation via windows scheduled task."""
         python = r"c:\instrument\apps\python3\python.exe"
         logrotate = r"c:\instrument\apps\epics\utils\logrotate.py"
-        task_cmd = f"cmd.exe /c start /min {python} {logrotate} > C:\Instrument\Var\logs\schtasks\logrotate.log 2>&1"
+        task_cmd = (
+            f"cmd.exe /c start /min {python} {logrotate} "
+            "> C:\Instrument\Var\logs\schtasks\logrotate.log 2>&1"
+        )
 
         admin_commands = AdminCommandBuilder()
         admin_commands.add_command(


### PR DESCRIPTION
`C:\Instrument\Var\logs\schtasks` is created by a recent config_env, if deploying elsewhere will need to manually create that directory