### PR TITLE
Suppress caRepeater delete message

### DIFF
--- a/installation_and_upgrade/remove_genie_python.bat
+++ b/installation_and_upgrade/remove_genie_python.bat
@@ -14,7 +14,7 @@ if exist "%remove_genie_python_path%" (
     echo.%remove_genie_python_path% | findstr /C:"Python_Build_">nul && (
 
         REM if caRepeater is running we can't remove directory
-        del /f "%remove_genie_python_path%\CaRepeater.exe"
+        del /f "%remove_genie_python_path%\CaRepeater.exe" >NUL 2>&1
         if exist "%remove_genie_python_path%\CaRepeater.exe" taskkill /f /im CaRepeater.exe
 
         REM Deletes directory tree + quiet.


### PR DESCRIPTION
Remove printing a stray `access denied` message - the delete is only used as a check as to whether to kill the process, so printing the delete failure message is not helpful