### PR TITLE
Default `expected_return_code` to `[0]`

### DIFF
--- a/installation_and_upgrade/ibex_install_utils/run_process.py
+++ b/installation_and_upgrade/ibex_install_utils/run_process.py
@@ -68,7 +68,7 @@ class RunProcess:
         if isinstance(expected_return_codes, int):
             expected_return_codes = [expected_return_codes]
         self._expected_return_codes = (
-            expected_return_codes if expected_return_codes is not None else []
+            expected_return_codes if expected_return_codes is not None else [0]
         )
         self.log_command_args = log_command_args
         if std_in is not None and self._capture_pipes:

--- a/installation_and_upgrade/truncate_database.bat
+++ b/installation_and_upgrade/truncate_database.bat
@@ -11,7 +11,7 @@ IF %errorlevel% neq 0 (
     goto ERROR
 )
 
-call "%LATEST_PYTHON%" "%~dp0IBEX_upgrade.py" --release_dir "%SOURCE%" --release_suffix "%SUFFIX%" --confirm_step truncate_database
+call python -u "%~dp0IBEX_upgrade.py" --release_dir "%SOURCE%" --release_suffix "%SUFFIX%" --confirm_step truncate_database
 IF %errorlevel% neq 0 goto ERROR
 call rmdir /s /q %UV_TEMP_VENV%
 


### PR DESCRIPTION
The default used to be `[0]` (see [here](https://github.com/ISISComputingGroup/ibex_utils/pull/264/files#diff-61e8c4900c83548b08a6ec5b8c3957148b027cc3124526b0fc0ae8e027b291eaL27) ) but was accidentally changed to `[]` (see [here](https://github.com/ISISComputingGroup/ibex_utils/pull/264/files#diff-61e8c4900c83548b08a6ec5b8c3957148b027cc3124526b0fc0ae8e027b291eaR71) )

This can be easily tested by running the `truncate_db` script locally, which uses `RunProcess` - no need to do backup step, just say yes to "truncate" step. Before this PR it'll fail, after it should pass.

Also fixed `truncate_db` script which was trying to use old non-uv way of calling python.